### PR TITLE
fix v3 validation test by pointing to a known-good v3 url

### DIFF
--- a/integrationtests/Paket.IntegrationTests/NuGetV3Specs.fs
+++ b/integrationtests/Paket.IntegrationTests/NuGetV3Specs.fs
@@ -27,7 +27,7 @@ let ``#2700-1 v3 works properly``() =
     let lockFile = LockFile.LoadFrom(Path.Combine(scenarioTempPath "i002700-1","paket.lock"))
     let mainGroup = lockFile.Groups.[Constants.MainDependencyGroup]
     mainGroup.Resolution.[PackageName "Microsoft.CSharp"].Source.Url
-    |> shouldEqual "https://www.myget.org/F/dotnet-core-svc/api/v3/index.json"
+    |> shouldEqual "https://api.nuget.org/v3/index.json"
 
 [<TestCase("https://api.nuget.org/v3/index.json")>]
 let ``#3030-1 version ordering should not change`` serviceUrl =

--- a/integrationtests/scenarios/i002700-1/before/paket.dependencies
+++ b/integrationtests/scenarios/i002700-1/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.myget.org/F/dotnet-core-svc/api/v3/index.json
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.CSharp prerelease

--- a/integrationtests/scenarios/i002700-2/before/paket.dependencies
+++ b/integrationtests/scenarios/i002700-2/before/paket.dependencies
@@ -1,3 +1,3 @@
-source https://www.myget.org/F/dotnet-core-svc
+source https://api.nuget.org/v3/index.json
 
 nuget Microsoft.CSharp prerelease


### PR DESCRIPTION
This fixes a failing test that has blocked green builds for several recent PRs.

The root cause of the failure was the pinned v3 nuget feed was no longer reachable, and the solution is providing a new url for one that is reachable (ie the main nuget feed).