### PR TITLE
thread through import_targets: false to msbuild exclude assets

### DIFF
--- a/docs/content/nuget-dependencies.md
+++ b/docs/content/nuget-dependencies.md
@@ -280,7 +280,7 @@ nuget Fody   content: once               // Install content files but do not ove
 nuget ServiceStack.Swagger content: true // Install content and always overwrite.
 ```
 
-The default is `content: true`.
+The default is `content: true`. `content: false` is equivalent to setting `ExcludeAssets=contentFiles` for a `PackageReference` in NuGet.
 
 ### Controlling whether content files should be copied to the output directory during build
 
@@ -308,7 +308,7 @@ source https://nuget.org/api/v2
 nuget Newtonsoft.Json copy_local: false
 ```
 
-The default is `copy_local: true`.
+The default is `copy_local: true`. `copy_local: false` is equivalent to setting `ExcludeAssets=runtime` for a `PackageReference` in NuGet.
 
 ### Importing `*.targets` and `*.props` files
 
@@ -321,6 +321,8 @@ source https://nuget.org/api/v2
 nuget Microsoft.Bcl.Build import_targets: false // Do not import *.targets and *.props.
 ```
 
+`import_targets: false` is equivalent to setting `ExcludeAssets=build;buildMultitargeting;buildTransitive` for a `PackageReference` in NuGet.
+
 ### License download
 
 If you want paket to download licenses automatically you can use the `license_download` modifier. It is disabled by default.
@@ -330,7 +332,6 @@ source https://nuget.org/api/v2
 
 nuget suave license_download: true
 ```
-
 
 ### Controlling assembly binding redirects
 

--- a/integrationtests/scenarios/packageref-specs/copy_local_false/before/Library.fs
+++ b/integrationtests/scenarios/packageref-specs/copy_local_false/before/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace test
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/integrationtests/scenarios/packageref-specs/copy_local_false/before/paket.dependencies
+++ b/integrationtests/scenarios/packageref-specs/copy_local_false/before/paket.dependencies
@@ -1,0 +1,5 @@
+source https://api.nuget.org/v3/index.json
+
+storage: none
+
+nuget FSharp.Core 5.0.2 copy_local: false

--- a/integrationtests/scenarios/packageref-specs/copy_local_false/before/paket.lock
+++ b/integrationtests/scenarios/packageref-specs/copy_local_false/before/paket.lock
@@ -1,0 +1,4 @@
+STORAGE: NONE
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FSharp.Core (5.0.2) - copy_local: false

--- a/integrationtests/scenarios/packageref-specs/copy_local_false/before/paket.references
+++ b/integrationtests/scenarios/packageref-specs/copy_local_false/before/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/integrationtests/scenarios/packageref-specs/copy_local_false/before/test.fsproj
+++ b/integrationtests/scenarios/packageref-specs/copy_local_false/before/test.fsproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+  <Import Project=".paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/packageref-specs/import_targets_false/before/Library.fs
+++ b/integrationtests/scenarios/packageref-specs/import_targets_false/before/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace test
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/integrationtests/scenarios/packageref-specs/import_targets_false/before/paket.dependencies
+++ b/integrationtests/scenarios/packageref-specs/import_targets_false/before/paket.dependencies
@@ -1,0 +1,5 @@
+source https://api.nuget.org/v3/index.json
+
+storage: none
+
+nuget FSharp.Core 5.0.2 import_targets: false

--- a/integrationtests/scenarios/packageref-specs/import_targets_false/before/paket.lock
+++ b/integrationtests/scenarios/packageref-specs/import_targets_false/before/paket.lock
@@ -1,0 +1,4 @@
+STORAGE: NONE
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FSharp.Core (5.0.2) - import_targets: false

--- a/integrationtests/scenarios/packageref-specs/import_targets_false/before/paket.references
+++ b/integrationtests/scenarios/packageref-specs/import_targets_false/before/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/integrationtests/scenarios/packageref-specs/import_targets_false/before/test.fsproj
+++ b/integrationtests/scenarios/packageref-specs/import_targets_false/before/test.fsproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+  <Import Project=".paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/packageref-specs/omit_content/before/Library.fs
+++ b/integrationtests/scenarios/packageref-specs/omit_content/before/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace test
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/integrationtests/scenarios/packageref-specs/omit_content/before/paket.dependencies
+++ b/integrationtests/scenarios/packageref-specs/omit_content/before/paket.dependencies
@@ -1,0 +1,5 @@
+source https://api.nuget.org/v3/index.json
+
+storage: none
+
+nuget FSharp.Core 5.0.2 content: none

--- a/integrationtests/scenarios/packageref-specs/omit_content/before/paket.lock
+++ b/integrationtests/scenarios/packageref-specs/omit_content/before/paket.lock
@@ -1,0 +1,4 @@
+STORAGE: NONE
+NUGET
+  remote: https://api.nuget.org/v3/index.json
+    FSharp.Core (5.0.2) - content: none

--- a/integrationtests/scenarios/packageref-specs/omit_content/before/paket.references
+++ b/integrationtests/scenarios/packageref-specs/omit_content/before/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/integrationtests/scenarios/packageref-specs/omit_content/before/test.fsproj
+++ b/integrationtests/scenarios/packageref-specs/omit_content/before/test.fsproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+  <Import Project=".paket\Paket.Restore.targets" />
+</Project>

--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -238,13 +238,15 @@
         <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
         <CopyLocal Condition="'%(PaketReferencesFileLinesInfo.Splits)' == '6'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
         <OmitContent Condition="'%(PaketReferencesFileLinesInfo.Splits)' == '7'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[6])</OmitContent>
+        <ImportTargets Condition="'%(PaketReferencesFileLinesInfo.Splits)' == '8'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[7])</ImportTargets>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
         <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
         <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' == '6' And %(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
         <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
-        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '7' And %(PaketReferencesFileLinesInfo.OmitContent) == 'true'">$(ExcludeAssets);contentFiles</ExcludeAssets>
+        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.OmitContent) == 'true'">$(ExcludeAssets);contentFiles</ExcludeAssets>
+        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.ImportTargets) == 'false'">$(ExcludeAssets);build;buildMultitargeting;buildTransitive</ExcludeAssets>
         <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
         <AllowExplicitVersion>true</AllowExplicitVersion>
       </PackageReference>


### PR DESCRIPTION
This should fix https://github.com/fsprojects/Paket/issues/4005 in a manner similar to #4040, by setting the appropriate ExcludeAssets flags when the user requests targets to not be imported.

This also fixes a bug in the Paket.Restore.targets I introduced with my fix in #4040 where the comparisons were incorrect. Inspection of the generated PackageReference in a msbuild structured build log revealed this.

With this change, the sample project described in #4005 builds without errors (since the targets aren't imported):

```
mkdir \temp\whatever
cd \temp\whatever
dotnet new console -f netcoreapp3.1 -lang F#
dotnet new tool-manifest
dotnet tool install paket
dotnet paket convert-from-nuget
dotnet paket add Grpc.Tools --project whatever
# edit the paket.references to include 'Grpc.Tools import_targets: false'
dotnet restore
dotnet build
```