### PR TITLE
CSX scripts: remove `namespace` declaration

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -278,11 +278,19 @@ let ``ignore assemblies that are not expected by the specified framework`` () =
     ] |> assertExpectations scenario ExpectationType.ShouldNotContain
 
 [<Test; Category("scriptgen")>]
-let ``scripts should contain the paket namespace`` () =
+let ``f# scripts should contain the paket namespace`` () =
+    let scenario = "add-namespace"
+    paket "install" scenario |> ignore
+    
+    [
+        "nlog.fsx", ["namespace PaketLoadScripts" ]
+    ] |> assertExpectations scenario ExpectationType.ShouldContain
+    
+[<Test; Category("scriptgen")>]
+let ``c# scripts should not contain the packet namespace`` () =
     let scenario = "add-namespace"
     paket "install" scenario |> ignore
     
     [
         "nlog.csx", ["namespace PaketLoadScripts" ]
-        "nlog.fsx", ["namespace PaketLoadScripts" ]
-    ] |> assertExpectations scenario ExpectationType.ShouldContain
+    ] |> assertExpectations scenario ExpectationType.ShouldNotContain

--- a/src/Paket.Core/Installation/ScriptGeneration.fs
+++ b/src/Paket.Core/Installation/ScriptGeneration.fs
@@ -113,10 +113,13 @@ module ScriptGeneration =
                 if self.UseRelativePath then
                     (Uri scriptFile.FullName).MakeRelativeUri(Uri libFile.FullName).ToString()
                 else libFile.FullName
+                
+            let paketNamespace =
+                match self.Lang with
+                | ScriptType.CSharp -> ""
+                | ScriptType.FSharp -> "namespace PaketLoadScripts\n"
 
-            let paketNamespace = "namespace PaketLoadScripts\n"
-
-            // create the approiate load string for the target resource
+            // create the appropriate load string for the target resource
             let refString (reference:ReferenceType)  =
                 let escapeString (s:string) =
                     s.Replace("\\", "\\\\").Replace("\"", "\\\"")


### PR DESCRIPTION
I use Roslyn C# scripting in several projects, and have discovered that `generate-load-scripts` looks like a nice way to prepare NuGet dependencies for deployment artifacts.

However, there is one issue: AFAIK C# scripts [don't support the `namespace` keyword](https://github.com/dotnet/roslyn/issues/4478).

This is a minor change that will simply omit the `namespace PaketLoadScripts` line in CSX scripts.