### PR TITLE
bump init TFM to net5.0

### DIFF
--- a/src/Paket.Core/PackageAnalysis/Environment.fs
+++ b/src/Paket.Core/PackageAnalysis/Environment.fs
@@ -118,6 +118,6 @@ module PaketEnv =
         let sources = [PackageSources.DefaultNuGetV3Source]
         let additionalLines = [
             "storage: none"
-            "framework: netcoreapp3.1, netstandard2.0, netstandard2.1"
+            "framework: net5.0, netstandard2.0, netstandard2.1"
         ]
         initWithContent sources additionalLines directory


### PR DESCRIPTION
let's have a more recent default, so that `paket init` on .net 5 SDKs doesn't silently fail for users.  based on [this reddit thread](https://www.reddit.com/r/fsharp/comments/otnxwt/cant_get_paket_to_work_for_the_simplest_case/)