### PR TITLE
add System.Memory to the ilrepack'd executables

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -327,6 +327,7 @@ Target "MergePaketTool" (fun _ ->
             "Paket.Core.dll"
             "System.Buffers.dll"
             "System.Configuration.ConfigurationManager.dll"
+            "System.Memory.dll"
             "System.Net.Http.WinHttpHandler.dll"
             "System.Security.Cryptography.Cng.dll"
             "System.Security.Cryptography.Pkcs.dll"


### PR DESCRIPTION
This fixes the immediate issue reported in #4062, but it may need more assemblies added based on testing/user responses.


After this change:
```
➜  Paket git:(add-system.memory) ✗ monop -r bin/merged/paket.exe | grep System.Memory
System.Memory`1
System.MemoryExtensions
```

System.Memory types are present in the merged executable.