### PR TITLE
final addition of system.numerics.vectors

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -329,6 +329,7 @@ Target "MergePaketTool" (fun _ ->
             "System.Configuration.ConfigurationManager.dll"
             "System.Memory.dll"
             "System.Net.Http.WinHttpHandler.dll"
+            "System.Numerics.Vectors.dll"
             "System.Runtime.CompilerServices.Unsafe.dll"
             "System.Security.Cryptography.Cng.dll"
             "System.Security.Cryptography.Pkcs.dll"


### PR DESCRIPTION
This should be the last missing dependency for #4062, after a few rounds of testing on my windows host.