### PR TITLE
Fix new Paket.Restore.targets 'PackageReadmeFile'

### DIFF
--- a/src/Paket.Core/embedded/Paket.Restore.targets
+++ b/src/Paket.Core/embedded/Paket.Restore.targets
@@ -365,8 +365,8 @@
               PackageLicenseFile="$(PackageLicenseFile)"
               PackageLicenseExpression="$(PackageLicenseExpression)"
               PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)"
-              PackageReadmeFile="$(PackageReadmeFile)"
-              NoDefaultExcludes="$(NoDefaultExcludes) "/>
+              Readme="$(PackageReadmeFile)"
+              NoDefaultExcludes="$(NoDefaultExcludes)"/>
 
     <PackTask Condition="$(UseMSBuild16_0_Pack)"
               PackItem="$(PackProjectInputFile)"


### PR DESCRIPTION
The new added support for PackageReadmeFile in MSBuild>=16.10 appears to use incorrect parameter name (caused failures for me). 
It should be 'Readme' rather than 'PackageReadmeFile'.
Extra space in NoDefaultExcludes also caused failure.