### PR TITLE
read env vars independently with nuget authentication

### DIFF
--- a/src/Paket.Core/Versioning/PackageSources.fs
+++ b/src/Paket.Core/Versioning/PackageSources.fs
@@ -90,12 +90,15 @@ let internal parseAuth(text:string, source) =
             else NetUtils.AuthType.Basic
 
         let auth =
-            match EnvironmentVariable.Create(username),
-                    EnvironmentVariable.Create(password) with
-            | Some userNameVar, Some passwordVar ->
-               {Username = userNameVar.Value; Password = passwordVar.Value; Type = authType }
-            | _, _ ->
-               {Username = username; Password = password; Type = authType }
+            { Username =
+                  EnvironmentVariable.Create(username)
+                  |> Option.map (fun var -> var.Value)
+                  |> Option.defaultValue username
+              Password =
+                  EnvironmentVariable.Create(password)
+                  |> Option.map (fun var -> var.Value)
+                  |> Option.defaultValue password
+              Type = authType }
 
         match auth with
         | {Username = username; Password = password} when username = "" && password = "" -> getAuth()


### PR DESCRIPTION
According to the documentation (image below), I can provide env vars for authentication, but in my case I tried to leave the username hardcoded and got 401.

Would this change be ok? I didn't test the code, I just created the username env var to make it work on my side.

Its weird that I still have to authenticate to consume the nuget packages hosted on a public github repo. 


![image](https://user-images.githubusercontent.com/688618/129944483-83ccac35-0a2c-4fdc-b203-f93d4dbb71ec.png)
