### PR TITLE
change the test to get the 'expected' version from the RELEASE_NOTES to ensure it stays in sync

### DIFF
--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -4,9 +4,8 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <!-- these three properties are set for some tests around assembly metadata parsing.
+    <!-- these two properties are set for some tests around assembly metadata parsing.
          they're written to the generated AssemblyInfo.fs -->
-    <Version>1.0.0</Version>
     <Authors>Two,Authors</Authors>
     <Description>A description</Description>
   </PropertyGroup>


### PR DESCRIPTION
Fixes a test failure that @forki saw after trying to release #4083 by making the test more data-driven instead of hard-coded. The Authors and Description property stayed the same, but that's because those are not set via MsBuild directly for the test projects, only the src/ projects.