### PR TITLE
add paket version to user-agent for nuget calls

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,4 +1,3 @@
-source https://nuget.org/api/v2
 source https://api.nuget.org/v3/index.json
 
 storage: none
@@ -40,7 +39,6 @@ github forki/FsUnit FsUnit.fs
 group Build
   content: none
   framework >= net461
-  source https://nuget.org/api/v2
   source https://api.nuget.org/v3/index.json
   source https://ci.appveyor.com/nuget/fsharp-formatting
 
@@ -59,6 +57,5 @@ group Build
   github enricosada/add_icon_to_exe:e11eda501acea369ac2950beb34b8888495bf21f rh/ResourceHacker.exe
 
 group FSharpDepManagerExtension
-  source https://nuget.org/api/v2
   source https://api.nuget.org/v3/index.json
   nuget FSharp.Core = 5.0.0 redirects: force

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 STORAGE: NONE
 CONTENT: NONE
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     Argu (6.1.1)
       FSharp.Core (>= 4.3.2) - restriction: >= netstandard2.0
       System.Configuration.ConfigurationManager (>= 4.4) - restriction: >= netstandard2.0
@@ -951,7 +951,7 @@ GROUP Build
 CONTENT: NONE
 RESTRICTION: >= net461
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     0x53A.ReferenceAssemblies.Paket (0.2)
     FAKE (4.64.17)
     FSharp.Compiler.Service (17.0.1)
@@ -982,5 +982,5 @@ GITHUB
     rh/ResourceHacker.exe (e11eda501acea369ac2950beb34b8888495bf21f)
 GROUP FSharpDepManagerExtension
 NUGET
-  remote: https://www.nuget.org/api/v2
+  remote: https://api.nuget.org/v3/index.json
     FSharp.Core (5.0) - redirects: force

--- a/src/Paket.Core/Common/NetUtils.fs
+++ b/src/Paket.Core/Common/NetUtils.fs
@@ -399,7 +399,6 @@ let createHttpHandlerRaw(url, auth: Auth option) : HttpMessageHandler =
     handler.UseProxy <- true
     handler :> _
 
-
 let createHttpHandler = 
     memoizeBy 
         // Truncates the url to only to host part, so there is only one handler per source/host.
@@ -408,7 +407,13 @@ let createHttpHandler =
         (fun (url : string, auth) -> url.Substring(0, url.IndexOf('/', 8) + 1), auth) 
         createHttpHandlerRaw 
 
-let createHttpClient (url,auth:Auth option) : HttpClient =
+let private paketVersion = 
+    let attrs = System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(false)
+
+    attrs
+    |> Seq.pick (fun a -> match a with | :? System.Reflection.AssemblyInformationalVersionAttribute as i -> Some i.InformationalVersion | _ -> None)
+
+let createHttpClient (url, auth:Auth option) : HttpClient =
     let handler = createHttpHandler (url, auth)
     let client = new HttpClient(handler)
     match auth with
@@ -432,7 +437,7 @@ let createHttpClient (url,auth:Auth option) : HttpClient =
     | Some(Token token) ->
         client.DefaultRequestHeaders.Authorization <-
             new System.Net.Http.Headers.AuthenticationHeaderValue("token", token)
-    client.DefaultRequestHeaders.Add("user-agent", "Paket")
+    client.DefaultRequestHeaders.Add("user-agent", sprintf "Paket (%s)" paketVersion)
     client
 
 #if USE_WEB_CLIENT_FOR_UPLOAD


### PR DESCRIPTION
Addresses [this comment](https://github.com/fsprojects/Paket/issues/4086#issuecomment-921333609) by plumbing through the current paket version into the user-agent for nuget calls.