### PR TITLE
added `--release-notes-file` option to pack

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -32,6 +32,8 @@ nuget NUnit ~> 3.12.0
 nuget NUnit3TestAdapter ~> 3.13.0
 nuget Microsoft.NET.Test.Sdk ~> 16.2.0
 
+nuget Fake.Core.ReleaseNotes ~> 5.20.4
+
 github fsharp/FAKE:0341a2e614eb2a7f34607cec914eb0ed83ce9add src/app/FakeLib/Globbing/Globbing.fs
 github fsprojects/FSharp.TypeProviders.SDK:dc5ac01a1ac288eceb1fd6f12a5d388236f4f8e5 src/AssemblyReader.fs
 github forki/FsUnit FsUnit.fs

--- a/paket.lock
+++ b/paket.lock
@@ -25,6 +25,14 @@ NUGET
       Microsoft.SourceLink.Bitbucket.Git (>= 1.0)
       Microsoft.SourceLink.GitHub (>= 1.0)
       Microsoft.SourceLink.GitLab (>= 1.0)
+    Fake.Core.ReleaseNotes (5.20.4)
+      Fake.Core.SemVer (>= 5.20.4) - restriction: >= netstandard2.0
+      Fake.Core.String (>= 5.20.4) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fake.Core.SemVer (5.20.4) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Fake.Core.String (5.20.4) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     FsCheck (2.15.3)
       FSharp.Core (>= 4.0.0.1) - restriction: && (< net452) (>= netstandard1.0) (< netstandard1.6)
       FSharp.Core (>= 4.2.3) - restriction: || (>= net452) (>= netstandard1.6)

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -532,6 +532,8 @@ type PackArgs =
 
     | [<Unique>] Project_Url of URL:string
     | [<Hidden;Unique;CustomCommandLine("project-url")>] Project_Url_Legacy of URL:string
+
+    | [<Unique>] Release_Notes_File of path:string
 with
     interface IArgParserTemplate with
         member this.Usage =
@@ -579,6 +581,8 @@ with
 
             | Project_Url _ -> "homepage URL for the package"
             | Project_Url_Legacy _ -> "[obsolete]"
+
+            | Release_Notes_File _ -> "path to release notes file"
 
 type PushArgs =
     | [<ExactlyOnce;MainCommand>] Package of path:string

--- a/src/Paket/Program.fs
+++ b/src/Paket/Program.fs
@@ -526,7 +526,7 @@ let pack (results : ParseResults<_>) =
         (results.TryGetResult PackArgs.Build_Platform,
          results.TryGetResult PackArgs.Build_Platform_Legacy)
         |> legacyOption results (ReplaceArgument("--build-platform", "buildplatform"))
-    let version =
+    let cliVersion =
         (results.TryGetResult PackArgs.Version,
          results.TryGetResult PackArgs.Version_Legacy)
         |> legacyOption results (ReplaceArgument("--version", "version"))
@@ -534,7 +534,7 @@ let pack (results : ParseResults<_>) =
         (results.GetResults PackArgs.Specific_Version,
          results.GetResults PackArgs.Specific_Version_Legacy)
         |> legacyList results (ReplaceArgument("--specific-version", "specific-version"))
-    let releaseNotes =
+    let cliReleaseNotes =
         (results.TryGetResult PackArgs.Release_Notes,
          results.TryGetResult PackArgs.Release_Notes_Legacy)
         |> legacyOption results (ReplaceArgument("--release-notes", "releaseNotes"))
@@ -583,6 +583,24 @@ let pack (results : ParseResults<_>) =
         (results.TryGetResult PackArgs.Project_Url,
          results.TryGetResult PackArgs.Project_Url_Legacy)
         |> legacyOption results (ReplaceArgument("--project-url", "project-url"))
+    let fileReleaseNotes =
+        match results.TryGetResult PackArgs.Release_Notes_File with
+        | Some file -> file |> Fake.Core.ReleaseNotes.load |> Some
+        | _ -> None
+    let releaseNotes =
+        match cliReleaseNotes with
+        | Some notes -> Some notes
+        | None -> 
+            match fileReleaseNotes with
+            | Some notes -> notes.Notes |> String.concat "\n" |> Some
+            | None -> None
+    let version =
+        match cliVersion with
+        | Some v -> Some v
+        | None ->   
+            match fileReleaseNotes with
+            | Some notes -> Some notes.NugetVersion
+            | None -> None
 
     Dependencies.Locate()
                 .Pack(outputPath,

--- a/src/Paket/paket.references
+++ b/src/Paket/paket.references
@@ -13,3 +13,4 @@ Microsoft.Win32.Registry
 System.Diagnostics.Process
 System.Diagnostics.TraceSource
 DotNet.ReproducibleBuilds
+Fake.Core.ReleaseNotes


### PR DESCRIPTION
Hey, I added an option to parse a standard-markdown release notes file (via Fake.Core.ReleaseNotes) which could simplify packaging a lot when not using FAKE scripts.

If there are any concerns/questions/suggestions please let me know.

Cheers