### PR TITLE
NuGet Cache: ensure for clitool nupkg is there even after skipped 2nd extraction

### DIFF
--- a/src/Paket.Core/Dependencies/NuGetCache.fs
+++ b/src/Paket.Core/Dependencies/NuGetCache.fs
@@ -520,7 +520,10 @@ let rec ExtractPackageToUserFolder(source: PackageSource, downloadedNupkgPath:st
                 let newNupkgPath = Path.Combine(parentOfParent.FullName, Path.GetFileName downloadedNupkgPath)
                 File.Move(downloadedNupkgPath, newNupkgPath)
                 do! extract newNupkgPath
-                File.Delete(newNupkgPath)
+                if File.Exists(downloadedNupkgPath) then
+                    File.Delete(newNupkgPath)
+                else
+                    File.Move(newNupkgPath, downloadedNupkgPath)
             else
                 do! extract downloadedNupkgPath
 


### PR DESCRIPTION
Fixes #4144

The problem is that we extract twice into the same place in case of clitool for some reason, but the second time NuGet seems to skip the extraction assuming it's already extracted - and hence not extracting the missing nupkg again. In this case we now move it back, instead of deleting it.

However, the clitool use case should be reviewed, the current implementation doesn't make much sense to me (it extracts twice into the same place; it prepares a different target folder, but this folder is not actually used for anything except logging). Also, is the .nuget/packages/.tools folder still the right place? Newer SDKs at least on Windows seem to put local tools just normally in the cache like any other package, and global tools instead into .dotnet/tools (but in a weird way).