### PR TITLE
Do not append TargetFramework subdirectory to OutputPath

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -1656,7 +1656,10 @@ module ProjectFile =
                         if String.IsNullOrWhiteSpace buildPlatform && attempted <> [] then
                             let tested = String.Join(", ", attempted)
                             traceWarnfn "No platform specified; found output path node for the %s platform after failing to find one for the following: %s" x tested
-                        Path.Combine(s.TrimEnd [|'\\'|] , targetFramework) |> normalizePath
+                        if (appendTargetFrameworkToOutputPath project) then
+                            Path.Combine(s.TrimEnd [|'\\'|] , targetFramework) |> normalizePath
+                        else
+                            s.TrimEnd [|'\\'|] |> normalizePath
 
         tryNextPlat platforms []
 


### PR DESCRIPTION
when AppendTargetFrameworkToOutputPath property is false

The change has not been tested

This commit is meant resolve issue  #4157 