### PR TITLE
Add Test for false AppendTargetFrameworkToOutputPath

### DIFF
--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -152,6 +152,7 @@
     <TestAsset Include="ProjectFile\TestData\EmptyCsharpGuid.csprojtest" />
     <TestAsset Include="ProjectFile\TestData\MicrosoftNetSdkWithTargetFramework.csprojtest" />
     <TestAsset Include="ProjectFile\TestData\AnalyzerProject.csprojtest" />
+    <TestAsset Include="ProjectFile\TestData\MicrosoftNetSdkWithOutputPathAndAppendTargetFrameworkFalse.csprojtest" />
     <Compile Include="ProjectFile\ConditionSpecs.fs" />
     <Compile Include="ProjectFile\TargetFrameworkSpecs.fs" />
     <Compile Include="ProjectFile\FileBuildActionSpecs.fs" />

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -93,6 +93,16 @@ let ``should detect output path for netsdk with outputPath csproj file``
     let expected = (System.IO.Path.Combine(@"bin", configuration,"netstandard1.4_bin", target) |> normalizePath)
     outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())
 
+[<Test>]
+let ``should detect output path for netsdk with outputPath and appendTargetFrameworkToOutputPath false csproj file``
+        ([<Values("MicrosoftNetSdkWithOutputPathAndAppendTargetFrameworkFalse.csprojtest")>] project)
+        ([<Values("Release")>] configuration) =
+    ensureDir ()
+    let projectFile = ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s" project).Value 
+    let target = projectFile.GetTargetProfiles().Head.ToString()
+    let outPath = projectFile.GetOutputDirectory configuration "" None
+    let expected = (System.IO.Path.Combine(@"bin", configuration,"netstandard1.4_bin") |> normalizePath)
+    outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())
 
 [<Test>]
 let ``should detect framework profile for ProjectWithConditions file`` () =

--- a/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
+++ b/tests/Paket.Tests/ProjectFile/OutputSpecs.fs
@@ -99,7 +99,6 @@ let ``should detect output path for netsdk with outputPath and appendTargetFrame
         ([<Values("Release")>] configuration) =
     ensureDir ()
     let projectFile = ProjectFile.TryLoad(sprintf "./ProjectFile/TestData/%s" project).Value 
-    let target = projectFile.GetTargetProfiles().Head.ToString()
     let outPath = projectFile.GetOutputDirectory configuration "" None
     let expected = (System.IO.Path.Combine(@"bin", configuration,"netstandard1.4_bin") |> normalizePath)
     outPath.ToLowerInvariant() |> shouldEqual (expected.ToLowerInvariant())

--- a/tests/Paket.Tests/ProjectFile/TestData/MicrosoftNetSdkWithOutputPathAndAppendTargetFrameworkFalse.csprojtest
+++ b/tests/Paket.Tests/ProjectFile/TestData/MicrosoftNetSdkWithOutputPathAndAppendTargetFrameworkFalse.csprojtest
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>TestPaket</AssemblyName>
+    <TargetFramework>netstandard1.4</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\netstandard1.4_bin\</OutputPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
When AppendTargetFrameworkToOutputPath is false, 'TargetFramework' subdir should not be appended to OutputDirectory

This commit is meant to test changes for issue #4157