### PR TITLE
Remove recommendation to git-ignore .paket/

### DIFF
--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -40,11 +40,10 @@ dotnet paket restore
 
 This will ensure Paket works in any .NET Core build environment.
 
-Make sure to add the following entries to your `.gitignore`:
+Make sure to add the following entry to your `.gitignore`:
 
 ```
 # Paket dependency manager
-.paket/
 paket-files/
 ```
 


### PR DESCRIPTION
It seems that it is not recommended to ignore files it contains. See https://github.com/fsprojects/Paket/issues/2840#issuecomment-488618766.

The inconsistent documentation caused confusion in https://github.com/SAFE-Stack/SAFE-template/pull/526