### PR TITLE
Proposal: increase process lock trials from 100 to 500 to support dotnet restore on larger solutions

### DIFF
--- a/src/Paket.Core/Common/Utils.fs
+++ b/src/Paket.Core/Common/Utils.fs
@@ -535,7 +535,7 @@ let RunInLockedAccessMode(lockedFolder,lockedAction: unit -> bool) =
                 skip <- true
 
     try
-        acquireLock DateTime.Now (TimeSpan.FromMinutes 10.) 100
+        acquireLock DateTime.Now (TimeSpan.FromMinutes 10.) 500
 
         let runDotNetRestore = lockedAction()
 


### PR DESCRIPTION
Otherwise, given how the mechanism works, I don't think a process lock max trial count of 100 could reliably support `dotnet restore` on solutions with more than 100 projects. The downside is potentially longer time until it aborts when there is a left-over lock, which should be rare though.

Alternatively maybe this could be made configurable.

Any thoughts?