### PR TITLE
paket init: Default framework restriction

### DIFF
--- a/src/Paket.Core/PackageAnalysis/Environment.fs
+++ b/src/Paket.Core/PackageAnalysis/Environment.fs
@@ -118,6 +118,7 @@ module PaketEnv =
         let sources = [PackageSources.DefaultNuGetV3Source]
         let additionalLines = [
             "storage: none"
-            "framework: net5.0, netstandard2.0, netstandard2.1"
+            "framework: auto-detect"
+            ""
         ]
         initWithContent sources additionalLines directory

--- a/src/Paket.Core/PackageAnalysis/Environment.fs
+++ b/src/Paket.Core/PackageAnalysis/Environment.fs
@@ -118,7 +118,6 @@ module PaketEnv =
         let sources = [PackageSources.DefaultNuGetV3Source]
         let additionalLines = [
             "storage: none"
-            "framework: auto-detect"
             ""
         ]
         initWithContent sources additionalLines directory


### PR DESCRIPTION
In response to #4186 , changes the default framework restriction in the paket.dependencies file when running paket init to be `auto-detect, and adds a newline at the end of the file.

While it is obviously maintainers choice to take or leave this, I also quite often "stumble" over the `net5` default restriction.
I would personally might pick something like the latest LTS, but `auto-detect` is the least … "getting in the way of the user".

Any advice/optinion is appreciated!