### PR TITLE
process dependencytree from top to bottom

### DIFF
--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -920,8 +920,12 @@ type LockFile (fileName:string, groups: Map<GroupName,LockFileGroup>) =
                     usedPackageKeys.Add k |> ignore
 
                     let deps = this.GetDirectDependenciesOfSafe(groupName,p.Name,referencesFile.FileName)
-                    toVisit := List.append toVisit.contents [(k,p,deps)]
+                    toVisit := List.append toVisit.contents [(k,p,deps)] 
         | None -> ()
+
+        toVisit := toVisit.Value 
+                    |> Seq.distinctBy (fun ((groupName,dep),packagageSettings,deps2) -> ( groupName, dep )) 
+                    |> List.ofSeq
 
         let visited = Dictionary<_,_>()
 


### PR DESCRIPTION
The dependency tree should be processed from top to bottom. Up to now, the dependencies are processed in no particular order.
If package 'A' is both directly and transitively dependent and an alias is configured for it, it can happen that the transitive dependency is processed first and therefore the alias setting is not taken into account. 

The direct dependencies should be processed first.