### PR TITLE
Allow FSharp.Core to be >= rather than = to 6.x

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ content: none
 
 nuget Newtonsoft.Json >= 10.0.3 redirects: force
 nuget Argu >= 5.1.0
-nuget FSharp.Core = 6.0.3 redirects: force
+nuget FSharp.Core >= 6.0.3 redirects: force
 nuget Chessie >= 0.6
 nuget Mono.Cecil ~> 0.11.1
 


### PR DESCRIPTION
#4260 