### PR TITLE
Wrap the path in /p:PackageReleaseNotesFile in quotes

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -155,7 +155,7 @@ let releaseNotesPath = releaseNotesProp release.Notes
 
 let packageProps = [
     sprintf "/p:Version=%s" release.NugetVersion
-    sprintf "/p:PackageReleaseNotesFile=%s" releaseNotesPath
+    sprintf "/p:PackageReleaseNotesFile=\"%s\"" releaseNotesPath
 ]
 
 Target "Build" (fun _ ->


### PR DESCRIPTION
I tried to build Paket locally on Windows with the build script, and it failed with this error
```
MSBUILD : error MSB1008: Only one project can be specified.
    Full command line: 'C:\Users\Richard Webb\AppData\Local\dotnetcore\sdk\8.0.302\MSBuild.dll -maxcpucount -verbosity:m -nologo -restore -consoleloggerparameters:Summary --property:Version=8.1.0-alpha004 --property:PackageReleaseNotesFile=C:\Users\Richard -property:Configuration=Release Paket.sln Webb\AppData\Local\Temp\tmpD7D0.tmp -distributedlogger:Microsoft.DotNet.Tools.MSBuild.MSBuildLogger,C:\Users\Richard Webb\AppData\Local\dotnetcore\sdk\8.0.302\dotnet.dll*Microsoft.DotNet.Tools.MSBuild.MSBuildForwardingLogger,C:\Users\Richard Webb\AppData\Local\dotnetcore\sdk\8.0.302\dotnet.dll'
  Switches appended by response files:
Switch: Webb\AppData\Local\Temp\tmpD7D0.tmp

For switch syntax, type "MSBuild -help"
Running build failed.
Error:
System.Exception: Build failed on "build" "Paket.sln" --configuration Release /p:Version=8.1.0-alpha004 /p:PackageReleaseNotesFile=C:\Users\Richard Webb\AppData\Local\Temp\tmpD7D0.tmp
   at Fake.DotNetCli.Build@224-3.Invoke(String message) in D:\code\fake\src\app\FakeLib\DotNetCLIHelper.fs:line 224
   at Fake.DotNetCli.Build(FSharpFunc`2 setBuildParams) in D:\code\fake\src\app\FakeLib\DotNetCLIHelper.fs:line 224
   at FSI_0005.Build.clo@161-6.Invoke(Unit _arg1)
   at Fake.TargetHelper.runSingleTarget(TargetTemplate`1 target) in D:\code\fake\src\app\FakeLib\TargetHelper.fs:line 626
```

Which seems to be because my profile directory has a space in the path, and that's confusing the MSBuild parameters.
This seems to avoid the issue for me locally in any case.