### PR TITLE
Add support for icon in paket.template.

### DIFF
--- a/docs/content/template-files.md
+++ b/docs/content/template-files.md
@@ -113,7 +113,8 @@ field of the same name in the `.nupkg`.
 * `readme`: This is a path to a readme file *in* the package. It should be added with the `files` block (see below).
 * `language`
 * `projectUrl`
-* `iconUrl`
+* `iconUrl` (deprecated by NuGet)
+* `icon` This is a path to an image file *in* the package. It should be added with the `files` block (see below).
 * `licenseExpression`: More info on what you can specify: <https://docs.microsoft.com/de-de/nuget/reference/nuspec#license>  
 * `licenseUrl` (deprecated by NuGet)
 * `repositoryType`

--- a/src/Paket.Core/Packaging/NupkgWriter.fs
+++ b/src/Paket.Core/Packaging/NupkgWriter.fs
@@ -186,6 +186,7 @@ module internal NupkgWriter =
 
         (!!?) "projectUrl" optional.ProjectUrl
         (!!?) "iconUrl" optional.IconUrl
+        (!!?) "icon" optional.Icon
         if optional.RequireLicenseAcceptance then
             !! "requireLicenseAcceptance" "true"
         !! "description" core.Description

--- a/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ProjectFile.fs
@@ -2095,6 +2095,7 @@ type ProjectFile with
             Language = prop "Langauge"
             ProjectUrl = prop "ProjectUrl"
             IconUrl = prop "IconUrl"
+            Icon = prop "Icon"
             LicenseExpression = prop "LicenseExpression"
             LicenseUrl = prop "LicenseUrl"
             Copyright = prop "Copyright"

--- a/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/TemplateFile.fs
@@ -145,6 +145,7 @@ type OptionalPackagingInfo =
       Language : string option
       ProjectUrl : string option
       IconUrl : string option
+      Icon : string option
       LicenseExpression : string option
       LicenseUrl : string option
       RepositoryUrl : string option
@@ -183,6 +184,7 @@ type OptionalPackagingInfo =
           RepositoryBranch = None
           RepositoryCommit = None
           IconUrl = None
+          Icon = None
           Copyright = None
           RequireLicenseAcceptance = false
           Tags = []
@@ -543,6 +545,7 @@ module internal TemplateFile =
           Language = get "language"
           ProjectUrl = get "projectUrl"
           IconUrl = get "iconUrl"
+          Icon = get "icon"
           RepositoryType = get "repositoryType"
           RepositoryUrl = get "repositoryUrl"
           RepositoryBranch = get "repositoryBranch"

--- a/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
+++ b/tests/Paket.Tests/Packaging/NuspecWriterSpecs.fs
@@ -362,6 +362,7 @@ let ``should not serialize all properties``() =
     <license type="expression">MIT</license>
     <projectUrl>http://www.somewhere.com</projectUrl>
     <iconUrl>http://www.somewhere.com/Icon</iconUrl>
+    <icon>some/icon.png</icon>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>A description</description>
     <summary>summary</summary>
@@ -397,6 +398,7 @@ second line</releaseNotes>
               ProjectUrl = Some "http://www.somewhere.com"
               LicenseExpression = Some "MIT"
               IconUrl = Some "http://www.somewhere.com/Icon"
+              Icon = Some "some/icon.png"
               Copyright = Some "Paket owners 2015"
               RequireLicenseAcceptance = true
               References = ["file1.dll";"file2.dll"]

--- a/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
+++ b/tests/Paket.Tests/Packaging/TemplateFileParsing.fs
@@ -151,6 +151,8 @@ projectUrl
     http://github.com/fsprojects/Chessie
 iconUrl
     https://raw.githubusercontent.com/fsprojects/Chessie/master/docs/files/img/logo.png
+icon
+    some/icon.png
 licenseExpression
     Unlicense
 requireLicenseAcceptance
@@ -199,6 +201,7 @@ let ``Optional fields are read`` (fileContent : string) =
     sut.Summary |> shouldEqual (Some "Railway-oriented programming for .NET")
     sut.Readme |> shouldEqual (Some "README.md")
     sut.IconUrl |> shouldEqual (Some "https://raw.githubusercontent.com/fsprojects/Chessie/master/docs/files/img/logo.png")
+    sut.Icon |> shouldEqual (Some "some/icon.png")
     sut.LicenseExpression |> shouldEqual (Some "Unlicense")
     sut.ProjectUrl |> shouldEqual (Some "http://github.com/fsprojects/Chessie")
     sut.Tags |> shouldEqual ["rop";"fsharp";"F#"]


### PR DESCRIPTION
This PR in combination with #3824 fixes #3710

Adds `icon` entry to paket.template to be able to set the nuget package icon the new way.
Updated the documentation to include this property and how the old `iconUrl` is now deprecated.