### PR TITLE
add a test for #4278 and adjustments for enabling warning as errors

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "9.0.0",
+      "version": "9.0.2",
       "commands": [
         "paket"
       ],

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,16 @@
 <Project>
- <PropertyGroup>
-	<TargetFrameworkRootPath>$(MSBuildThisFileDirectory)packages\build\0x53A.ReferenceAssemblies.Paket\tools\framework</TargetFrameworkRootPath>
- </PropertyGroup>
-
- <Import Project="$(PackageReleaseNotesFile)" Condition=" Exists('$(PackageReleaseNotesFile)') " />
-
+  <PropertyGroup>
+    <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)packages\build\0x53A.ReferenceAssemblies.Paket\tools\framework</TargetFrameworkRootPath>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--
+    NU1902: Package 'xxx' X.Y.Z has a known moderate severity vulnerability, https://URI
+    NU1903: Package 'xxx' X.Y.Z has a known high severity vulnerability, https://URI
+    NU1904: Package 'xxx' X.Y.Z has a known critical severity vulnerability, https://URI
+    FS0086: The '>' operator should not normally be redefined. To define overloaded comparison semantics for a particular type, implement the 'System.IComparable' interface in the definition of that type.
+    FS0040: This and other recursive references to the object(s) being defined will be checked for initialization-soundness at runtime through the use of a delayed reference. This is because you are defining one or more recursive objects, rather than recursive functions.
+    FS0044: This construct is deprecated.
+    -->
+   <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1903;NU1904;FS0086;FS0040;FS0044</WarningsNotAsErrors>
+  </PropertyGroup>
+  <Import Project="$(PackageReleaseNotesFile)" Condition=" Exists('$(PackageReleaseNotesFile)') " />
 </Project>

--- a/Paket.sln
+++ b/Paket.sln
@@ -114,6 +114,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1C9A57E4-9D94-44D1-A106-FC588B7B72DE}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.DependencyManager.Paket", "src\FSharp.DependencyManager.Paket\FSharp.DependencyManager.Paket.fsproj", "{6C531B7C-B52D-48FA-9EDD-519CCE151F19}"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "8.0.403",
+      "version": "9.0.100",
       "rollForward": "latestMinor"
     }
 }

--- a/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/InstallSpecs.fs
@@ -442,6 +442,12 @@ let ``#4012 Support .net 6 (part 1)``() =
     use __ = cleanup
     newLockFile.Groups.[GroupName "main"].Resolution.ContainsKey (PackageName "Argu") |> shouldEqual true
 
+[<Test>]
+let ``#4278 Support net 9 windows platform`` () =
+    let cleanup, newLockFile = install "i004278-net90-windows-fails"
+    use _ = cleanup
+    newLockFile.Groups.[GroupName "main"].Resolution.ContainsKey (PackageName "CsvHelper") |> shouldEqual true
+
 #if INTERACTIVE
 ;;
 

--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -738,7 +738,7 @@ let ``#4003 dotnet pack of a global tool with p2p``() =
 let ``#4004 dotnet pack using different versions``() =
     let project = "lib1"
     let scenario = "i004004-pack-version"
-    use __ = prepareSdk scenario
+    use _ = prepareSdk scenario
 
     let rootPath = scenarioTempPath scenario
 
@@ -763,7 +763,7 @@ let ``#4004 dotnet pack using different versions``() =
 let ``#3599 dotnet pack should work with build metadata``() =
     let project = "lib1"
     let scenario = "i003599-pack-build-meta"
-    prepareSdk scenario
+    use _ = prepareSdk scenario
 
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/App.xaml
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="PaketTest.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:PaketTest"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/App.xaml.cs
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/App.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace PaketTest;
+
+/// <summary>
+/// Interaction logic for App.xaml
+/// </summary>
+public partial class App : Application
+{
+}
+

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/AssemblyInfo.cs
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/MainWindow.xaml
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/MainWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="PaketTest.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:PaketTest"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+
+    </Grid>
+</Window>

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/MainWindow.xaml.cs
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/MainWindow.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PaketTest;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/PaketTest.csproj
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/PaketTest.csproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/paket.references
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/PaketTest/paket.references
@@ -1,0 +1,1 @@
+CsvHelper

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/before.sln
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/before.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PaketTest", "PaketTest\PaketTest.csproj", "{4E70655A-3F36-46DB-822B-62BF00963125}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4E70655A-3F36-46DB-822B-62BF00963125}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E70655A-3F36-46DB-822B-62BF00963125}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E70655A-3F36-46DB-822B-62BF00963125}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E70655A-3F36-46DB-822B-62BF00963125}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {58D025CC-E691-4519-A616-811DBE290103}
+	EndGlobalSection
+EndGlobal

--- a/integrationtests/scenarios/i004278-net90-windows-fails/before/paket.dependencies
+++ b/integrationtests/scenarios/i004278-net90-windows-fails/before/paket.dependencies
@@ -1,0 +1,3 @@
+source https://www.nuget.org/api/v2
+
+nuget CsvHelper

--- a/src/Paket.Core/Dependencies/DependenciesFileParser.fs
+++ b/src/Paket.Core/Dependencies/DependenciesFileParser.fs
@@ -254,8 +254,8 @@ module DependenciesFileParser =
                 Some (Package(name,operator + " " + version, String.Join(" ",rest) |> removeComment))
             | name :: version :: rest when isVersion version ->
                 Some (Package(name,version,String.Join(" ",rest) |> removeComment))
-            | name :: rest -> Some (Package(name,">= 0", String.Join(" ",rest) |> removeComment))
             | [name] -> Some (Package(name,">= 0",""))
+            | name :: rest -> Some (Package(name,">= 0", String.Join(" ",rest) |> removeComment))
             | _ -> failwithf "could not retrieve NuGet package from %s" trimmed
         | _ -> None
 
@@ -277,8 +277,8 @@ module DependenciesFileParser =
                 Some (CliTool(name,operator + " " + version, String.Join(" ",rest) |> removeComment))
             | name :: version :: rest when isVersion version ->
                 Some (CliTool(name,version,String.Join(" ",rest) |> removeComment))
-            | name :: rest -> Some (CliTool(name,">= 0", String.Join(" ",rest) |> removeComment))
             | [name] -> Some (CliTool(name,">= 0",""))
+            | name :: rest -> Some (CliTool(name,">= 0", String.Join(" ",rest) |> removeComment))
             | _ -> failwithf "could not retrieve cli tool from %s" trimmed
         | _ -> None
 

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -183,8 +183,6 @@ let calculateNuGet2Path(nugetUrl:string) =
     match nugetUrl.TrimEnd([|'/'|]) with
     | "http://api.nuget.org/v3/index.json" -> Some "http://nuget.org/api/v2"
     | "https://api.nuget.org/v3/index.json" -> Some "https://nuget.org/api/v2"
-    | "http://api.nuget.org/v3/index.json" -> Some "http://www.nuget.org/api/v2"
-    | "https://api.nuget.org/v3/index.json" -> Some "https://www.nuget.org/api/v2"
     | url when url.EndsWith("/nuget/v3/index.json") -> Some (url.Replace("/nuget/v3/index.json","/nuget/v2"))
     | url when url.EndsWith("/api/v3/index.json") && url.Contains("visualstudio.com") -> Some (url.Replace("/api/v3/index.json",""))
     | url when url.EndsWith("/api/v3/index.json") && url.Contains("myget.org") -> Some (url.Replace("/api/v3/index.json",""))

--- a/src/Paket.Core/Packaging/PackageMetaData.fs
+++ b/src/Paket.Core/Packaging/PackageMetaData.fs
@@ -217,7 +217,7 @@ let getTargetDir (project : ProjectFile) targetProfile =
             | Some targetProfile -> sprintf "lib/%O/" targetProfile
             | None -> "lib/"
 
-let findDependencies (dependenciesFile : DependenciesFile) config platform (template : TemplateFile) (project : ProjectFile) lockDependencies minimumFromLockFile pinProjectReferences interprojectReferencesConstraint (projectWithTemplates : Map<string, Lazy<'TemplateFile> * ProjectFile * bool>) includeReferencedProjects (version :SemVerInfo option) cache =
+let findDependencies (dependenciesFile : DependenciesFile) config platform (template : TemplateFile) (project : ProjectFile) lockDependencies minimumFromLockFile pinProjectReferences interprojectReferencesConstraint (projectWithTemplates : Map<string, Lazy<_> * ProjectFile * bool>) includeReferencedProjects (version :SemVerInfo option) cache =
     let includeReferencedProjects = template.IncludeReferencedProjects || includeReferencedProjects
 
     let interprojectReferencesConstraint =

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -121,7 +121,7 @@ with
             | Username _ -> "provide username"
             | Password _ -> "provide password"
             | AuthType _ -> "specify authentication type: basic|ntlm (default: basic)"
-            | Verify _ -> "specify in case you want to verify the credentials"
+            | Verify -> "specify in case you want to verify the credentials"
 
 type ConvertFromNugetArgs =
     | [<Unique;AltCommandLine("-f")>] Force
@@ -563,21 +563,21 @@ with
             | Release_Notes_Legacy _ -> "[obsolete]"
 
             | Lock_Dependencies -> "use version constraints from paket.lock instead of paket.dependencies"
-            | Lock_Dependencies_Legacy _ -> "[obsolete]"
+            | Lock_Dependencies_Legacy -> "[obsolete]"
 
             | Lock_Dependencies_To_Minimum -> "use version constraints from paket.lock instead of paket.dependencies and add them as a minimum version; --lock-dependencies overrides this option"
-            | Lock_Dependencies_To_Minimum_Legacy _ -> "[obsolete]"
+            | Lock_Dependencies_To_Minimum_Legacy -> "[obsolete]"
 
             | Pin_Project_References -> "pin dependencies generated from project references to exact versions (=) instead of using minimum versions (>=); with --lock-dependencies project references will be pinned even if this option is not specified"
-            | Pin_Project_References_Legacy _ -> "[obsolete]"
+            | Pin_Project_References_Legacy -> "[obsolete]"
 
             | Interproject_References _ -> "set constraints for referenced project versions"
 
             | Symbols -> "create symbol and source packages in addition to library and content packages"
-            | Symbols_Legacy _ -> "[obsolete]"
+            | Symbols_Legacy -> "[obsolete]"
 
             | Include_Referenced_Projects -> "include symbols and source from referenced projects"
-            | Include_Referenced_Projects_Legacy _ -> "[obsolete]"
+            | Include_Referenced_Projects_Legacy -> "[obsolete]"
 
             | Project_Url _ -> "homepage URL for the package"
             | Project_Url_Legacy _ -> "[obsolete]"

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/CacheDownloadStrategyTest.cs
@@ -184,7 +184,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             var content = Guid.NewGuid().ToByteArray();
-            var sha = new SHA256Managed();
+            var sha = SHA256.Create();
             var checksum = sha.ComputeHash(new MemoryStream(content));
             var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
             var hashFile = new PaketHashFile(new List<string> { hash + " paket.exe" });
@@ -212,7 +212,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             var content = Guid.NewGuid().ToByteArray();
-            var sha = new SHA256Managed();
+            var sha = SHA256.Create();
             var checksum = sha.ComputeHash(new MemoryStream(content));
             var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
             var hashFile = new PaketHashFile(new List<string> { hash + " paket.exe" });

--- a/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
+++ b/tests/Paket.Bootstrapper.Tests/DownloadStrategies/GitHubDownloadStrategyTest.cs
@@ -89,7 +89,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             var content = Guid.NewGuid().ToByteArray();
-            var sha = new SHA256Managed();
+            var sha = SHA256.Create();
             var checksum = sha.ComputeHash(new MemoryStream(content));
             var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
             mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(() => new MemoryStream(Guid.NewGuid().ToByteArray()));
@@ -109,7 +109,7 @@ namespace Paket.Bootstrapper.Tests.DownloadStrategies
         {
             //arrange
             var content = Guid.NewGuid().ToByteArray();
-            var sha = new SHA256Managed();
+            var sha = SHA256.Create();
             var checksum = sha.ComputeHash(new MemoryStream(content));
             var hash = BitConverter.ToString(checksum).Replace("-", String.Empty);
             mockFileProxy.Setup(x => x.OpenRead(It.IsAny<string>())).Returns(new MemoryStream(content));

--- a/tests/Paket.Bootstrapper.Tests/HelperProxies/EnvWebProxyShould.cs
+++ b/tests/Paket.Bootstrapper.Tests/HelperProxies/EnvWebProxyShould.cs
@@ -29,7 +29,6 @@ namespace Paket.Bootstrapper.Tests.HelperProxies
             using (new DisposableEnvVar("https_proxy"))
             {
                 var envProxy = TestHelper.NoSingletonProxyProvider.EnvProxy;
-                IWebProxy proxy;
                 Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("http://github.com"), out _));
                 Assert.IsFalse(envProxy.TryGetProxyFor(new Uri("https://github.com"), out _));
             }

--- a/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
+++ b/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
@@ -150,7 +150,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -198,7 +198,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -254,7 +254,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -344,7 +344,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -401,7 +401,7 @@ group Other2
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -448,7 +448,7 @@ Newtonsoft.Json
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 


### PR DESCRIPTION
Giving it a try on CI, locally, for the added test, I face some MSbuild nonsense:

> C:\dev\src\github\fsprojects\Paket\integrationtests\scenarios\i004278-net90-windows-fails\before\before.sln.metaproj : error MSB4126: The specified solution configuration "Debug|x64" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration. [C:\dev\src\github\fsprojects\Paket\integrationtests\scenarios\i004278-net90-windows-fails\before\before.sln]

I did minor tweaks to have warning as errors, the change in [src/Paket.Core/Dependencies/DependenciesFileParser.fs](https://github.com/fsprojects/Paket/compare/master...smoothdeveloper:fix-4278?expand=1#diff-72dc78df0df0be9d06b144a35c5e09e2ba716cf53f5e340fe74254889781dc1a) is worth some attention, but the rest is straight forward.