### PR TITLE
Fix script generation if package contains FSharp.Core name

### DIFF
--- a/src/Paket.Core/Installation/ScriptGeneration.fs
+++ b/src/Paket.Core/Installation/ScriptGeneration.fs
@@ -55,9 +55,9 @@ module ScriptGeneration =
         refls |> List.filter ( fun ref ->
             if scriptType = ScriptType.FSharp then 
                 match ref with 
-                | Assembly info -> not (String.containsIgnoreCase "FSharp.Core" info.Name)
-                | Framework info -> not (String.containsIgnoreCase "FSharp.Core" info)
-                | LoadScript info -> not (String.containsIgnoreCase "FSharp.Core" info)
+                | Assembly info -> not (String.startsWithIgnoreCase "FSharp.Core" info.Name)
+                | Framework info -> not (String.startsWithIgnoreCase "FSharp.Core" info)
+                | LoadScript info -> not (String.startsWithIgnoreCase "FSharp.Core" info)
             else true
         )
 

--- a/tests/Paket.Tests/ScriptGeneration/LoadingScriptTests.fs
+++ b/tests/Paket.Tests/ScriptGeneration/LoadingScriptTests.fs
@@ -51,6 +51,34 @@ let ``generateFSharpScript generates load script``() =
     | Generate [ ReferenceType.LoadScript _ ] -> ()
     | _ -> Assert.Fail("generated script was expected to be a single load script")
 
+[<Test>]
+let ``generateFSharpScript not generates load script for FSharp.Core``() =
+    let output = ScriptGeneration.generateScript ScriptType.FSharp {
+        PackageName                  = Paket.Domain.PackageName "FSharp.Core"
+        DependentScripts             = List.empty
+        FrameworkReferences          = List.empty
+        OrderedDllReferences         = List.empty
+        PackageLoadScripts           = ["foo.fsx"]
+    }
+
+    match output with
+    | DoNotGenerate -> ()
+    | _ -> Assert.Fail("generated script was expected to be a single load script")
+
+[<Test>]
+let ``generateFSharpScript generates load script if contains FSharp.Core but not FSharp.Core``() =
+    let output = ScriptGeneration.generateScript ScriptType.FSharp {
+        PackageName                  = Paket.Domain.PackageName "Company.FSharp.Core"
+        DependentScripts             = List.empty
+        FrameworkReferences          = List.empty
+        OrderedDllReferences         = List.empty
+        PackageLoadScripts           = ["foo.fsx"]
+    }
+
+    match output with
+    | Generate [ ReferenceType.LoadScript _ ] -> ()
+    | _ -> Assert.Fail("generated script was expected to be a single load script")
+
 
 
 let lockFileData = """NUGET


### PR DESCRIPTION
It's normal to ignore FSharp.Core, but not Company.FSharp.Core, CustomFSharp.Core ou CustomFSharp.CoreCustom