### PR TITLE
Fixed a Few Compiler Warnings

### DIFF
--- a/integrationtests/Paket.IntegrationTests/PackSpecs.fs
+++ b/integrationtests/Paket.IntegrationTests/PackSpecs.fs
@@ -763,7 +763,7 @@ let ``#4004 dotnet pack using different versions``() =
 let ``#3599 dotnet pack should work with build metadata``() =
     let project = "lib1"
     let scenario = "i003599-pack-build-meta"
-    prepareSdk scenario
+    prepareSdk scenario |> ignore
 
     let rootPath = scenarioTempPath scenario
     let outPath = Path.Combine(rootPath, "out")

--- a/src/Paket.Core/Dependencies/DependenciesFileParser.fs
+++ b/src/Paket.Core/Dependencies/DependenciesFileParser.fs
@@ -255,7 +255,6 @@ module DependenciesFileParser =
             | name :: version :: rest when isVersion version ->
                 Some (Package(name,version,String.Join(" ",rest) |> removeComment))
             | name :: rest -> Some (Package(name,">= 0", String.Join(" ",rest) |> removeComment))
-            | [name] -> Some (Package(name,">= 0",""))
             | _ -> failwithf "could not retrieve NuGet package from %s" trimmed
         | _ -> None
 
@@ -278,7 +277,6 @@ module DependenciesFileParser =
             | name :: version :: rest when isVersion version ->
                 Some (CliTool(name,version,String.Join(" ",rest) |> removeComment))
             | name :: rest -> Some (CliTool(name,">= 0", String.Join(" ",rest) |> removeComment))
-            | [name] -> Some (CliTool(name,">= 0",""))
             | _ -> failwithf "could not retrieve cli tool from %s" trimmed
         | _ -> None
 

--- a/src/Paket.Core/Dependencies/NuGetV3.fs
+++ b/src/Paket.Core/Dependencies/NuGetV3.fs
@@ -183,8 +183,6 @@ let calculateNuGet2Path(nugetUrl:string) =
     match nugetUrl.TrimEnd([|'/'|]) with
     | "http://api.nuget.org/v3/index.json" -> Some "http://nuget.org/api/v2"
     | "https://api.nuget.org/v3/index.json" -> Some "https://nuget.org/api/v2"
-    | "http://api.nuget.org/v3/index.json" -> Some "http://www.nuget.org/api/v2"
-    | "https://api.nuget.org/v3/index.json" -> Some "https://www.nuget.org/api/v2"
     | url when url.EndsWith("/nuget/v3/index.json") -> Some (url.Replace("/nuget/v3/index.json","/nuget/v2"))
     | url when url.EndsWith("/api/v3/index.json") && url.Contains("visualstudio.com") -> Some (url.Replace("/api/v3/index.json",""))
     | url when url.EndsWith("/api/v3/index.json") && url.Contains("myget.org") -> Some (url.Replace("/api/v3/index.json",""))

--- a/src/Paket/Commands.fs
+++ b/src/Paket/Commands.fs
@@ -121,7 +121,7 @@ with
             | Username _ -> "provide username"
             | Password _ -> "provide password"
             | AuthType _ -> "specify authentication type: basic|ntlm (default: basic)"
-            | Verify _ -> "specify in case you want to verify the credentials"
+            | Verify -> "specify in case you want to verify the credentials"
 
 type ConvertFromNugetArgs =
     | [<Unique;AltCommandLine("-f")>] Force
@@ -563,21 +563,21 @@ with
             | Release_Notes_Legacy _ -> "[obsolete]"
 
             | Lock_Dependencies -> "use version constraints from paket.lock instead of paket.dependencies"
-            | Lock_Dependencies_Legacy _ -> "[obsolete]"
+            | Lock_Dependencies_Legacy -> "[obsolete]"
 
             | Lock_Dependencies_To_Minimum -> "use version constraints from paket.lock instead of paket.dependencies and add them as a minimum version; --lock-dependencies overrides this option"
-            | Lock_Dependencies_To_Minimum_Legacy _ -> "[obsolete]"
+            | Lock_Dependencies_To_Minimum_Legacy -> "[obsolete]"
 
             | Pin_Project_References -> "pin dependencies generated from project references to exact versions (=) instead of using minimum versions (>=); with --lock-dependencies project references will be pinned even if this option is not specified"
-            | Pin_Project_References_Legacy _ -> "[obsolete]"
+            | Pin_Project_References_Legacy -> "[obsolete]"
 
             | Interproject_References _ -> "set constraints for referenced project versions"
 
             | Symbols -> "create symbol and source packages in addition to library and content packages"
-            | Symbols_Legacy _ -> "[obsolete]"
+            | Symbols_Legacy -> "[obsolete]"
 
             | Include_Referenced_Projects -> "include symbols and source from referenced projects"
-            | Include_Referenced_Projects_Legacy _ -> "[obsolete]"
+            | Include_Referenced_Projects_Legacy -> "[obsolete]"
 
             | Project_Url _ -> "homepage URL for the package"
             | Project_Url_Legacy _ -> "[obsolete]"

--- a/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
+++ b/tests/Paket.Tests/InstallModel/PaketPropsTests.fs
@@ -150,7 +150,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -198,7 +198,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -254,7 +254,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -344,7 +344,7 @@ group Other1
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -401,7 +401,7 @@ group Other2
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 
@@ -448,7 +448,7 @@ Newtonsoft.Json
             yield! packagesInGroup ]
 
     let outPath = System.IO.Path.GetTempFileName()
-    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath)
+    Paket.RestoreProcess.createPaketPropsFile lockFile Seq.empty refFile packages (FileInfo outPath) |> ignore
 
     let doc = XDocument.Load(outPath, LoadOptions.PreserveWhitespace)
 


### PR DESCRIPTION
Here are a few fixes to some compiler warnings we are getting on builds. I'm wanting to try and go through and attempt to do a few rounds of cleanup to make real issues more obvious when we encounter them.

I'll be making separate PRs for:
1. InstallModel.CreateFromLibs -> InstallModel.CreateFromContent
  1. There are a lot of warnings we can clean up here
2. build.fsx
  1. I think we can eliminate a lot of these warnings by updating our FAKE dependencies and referencing the modern core namespaces instead