### PR TITLE
Add "generate_path_property" option

### DIFF
--- a/src/Paket.Core/Dependencies/DependenciesFileParser.fs
+++ b/src/Paket.Core/Dependencies/DependenciesFileParser.fs
@@ -216,6 +216,7 @@ module DependenciesFileParser =
     | SpecificVersion of bool
     | CopyContentToOutputDir of CopyToOutputDirectorySettings
     | GenerateLoadScripts of bool option
+    | GeneratePathProperty of bool
     | ReferenceCondition of string
     | Redirects of BindingRedirectsSettings option
     | ResolverStrategyForTransitives of ResolverStrategy option
@@ -392,6 +393,7 @@ module DependenciesFileParser =
                 | String.EqualsIC "off" | String.EqualsIC "false" -> Some false
                 | _ -> None
             Some (ParserOptions (ParserOption.GenerateLoadScripts setting))
+        | String.RemovePrefix "generate_path_property" trimmed -> (Some (ParserOptions (ParserOption.GeneratePathProperty(trimmed.Replace(":","").Trim() = "true"))))
         | _ -> None
 
     let private (|SourceFile|_|) (line:string) =
@@ -486,6 +488,7 @@ module DependenciesFileParser =
         | OmitContent omit                               -> { current.Options with Settings = { current.Options.Settings with OmitContent = Some omit } }
         | ReferenceCondition condition                   -> { current.Options with Settings = { current.Options.Settings with ReferenceCondition = Some condition } }
         | GenerateLoadScripts mode                       -> { current.Options with Settings = { current.Options.Settings with GenerateLoadScripts = mode }}
+        | GeneratePathProperty mode                      -> { current.Options with Settings = { current.Options.Settings with GeneratePathProperty = Some mode }}
 
     let private parseLine fileName checkDuplicates (lineNo, state: DependenciesGroup list) line =
         match state with

--- a/src/Paket.Core/PaketConfigFiles/LockFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/LockFile.fs
@@ -91,7 +91,11 @@ module LockFileSerializer =
 
         match options.Settings.FrameworkRestrictions |> getExplicitRestriction with
         | FrameworkRestriction.HasNoRestriction -> ()
-        | list  -> yield "RESTRICTION: " + list.ToString() ]
+        | list  -> yield "RESTRICTION: " + list.ToString()
+
+        match options.Settings.GeneratePathProperty with
+        | Some x -> yield "GENERATE-PATH-PROPERTY: " + x.ToString().ToUpper()
+        | None -> () ]
 
     /// [omit]
     let serializePackages options (resolved : PackageResolution) =
@@ -268,6 +272,7 @@ module LockFileParser =
     | ImportTargets of bool
     | LicenseDownload of bool
     | GenerateLoadScripts of bool option
+    | GeneratePathProperty of bool
     | FrameworkRestrictions of FrameworkRestrictions
     | CopyLocal of bool
     | SpecificVersion of bool
@@ -322,6 +327,7 @@ module LockFileParser =
                 | _ -> None
 
             InstallOption (GenerateLoadScripts setting)
+        | _, String.RemovePrefix "GENERATE-PATH-PROPERTY:" trimmed -> InstallOption(GeneratePathProperty(trimmed.Trim() = "TRUE"))
         | _, String.RemovePrefix "COPY-CONTENT-TO-OUTPUT-DIR:" trimmed ->
             let setting =
                 match trimmed.Replace(":","").Trim().ToLowerInvariant() with
@@ -411,6 +417,7 @@ module LockFileParser =
         | CopyContentToOutputDir mode -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with CopyContentToOutputDirectory = Some mode }}
         | FrameworkRestrictions r -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with FrameworkRestrictions = r }}
         | OmitContent omit -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with OmitContent = Some omit }}
+        | GeneratePathProperty mode -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with GeneratePathProperty = Some mode }}
         | GenerateLoadScripts mode -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with GenerateLoadScripts = mode }}
         | ReferenceCondition condition -> { currentGroup.Options with Settings = { currentGroup.Options.Settings with ReferenceCondition = Some condition }}
         | DirectDependenciesResolverStrategy strategy -> { currentGroup.Options with ResolverStrategyForDirectDependencies = strategy }

--- a/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
+++ b/src/Paket.Core/PaketConfigFiles/ReferencesFile.fs
@@ -130,7 +130,7 @@ type ReferencesFile =
             { ReferencesFile.FromLines lines with FileName = fileName }
         with e -> raise (new Exception(sprintf "Could not parse reference file '%s': %s" fileName e.Message, e))
 
-    member this.AddNuGetReference(groupName, packageName : PackageName, embedInteropTypes: bool, copyLocal: bool, specificVersion: bool, importTargets: bool, frameworkRestrictions, includeVersionInPath, downloadLicense, omitContent : bool, createBindingRedirects, referenceCondition) =
+    member this.AddNuGetReference(groupName, packageName : PackageName, embedInteropTypes: bool, copyLocal: bool, specificVersion: bool, importTargets: bool, frameworkRestrictions, includeVersionInPath, downloadLicense, omitContent : bool, createBindingRedirects, referenceCondition, generatePathProperty) =
         let package: PackageInstallSettings =
             { Name = packageName
               Settings =
@@ -149,6 +149,7 @@ type ReferencesFile =
                     Aliases = Map.empty
                     OmitContent = if omitContent then Some ContentCopySettings.Omit else None
                     GenerateLoadScripts = None
+                    GeneratePathProperty = if generatePathProperty then Some generatePathProperty else None
                     Simplify = None } }
 
         match this.Groups |> Map.tryFind groupName with
@@ -175,7 +176,7 @@ type ReferencesFile =
                 { this with Groups = newGroups }
 
     member this.AddNuGetReference(groupName, packageName : PackageName) =
-        this.AddNuGetReference(groupName, packageName, false, true, true, true, ExplicitRestriction FrameworkRestriction.NoRestriction, false, false, false, None, null)
+        this.AddNuGetReference(groupName, packageName, false, true, true, true, ExplicitRestriction FrameworkRestriction.NoRestriction, false, false, false, None, null, false)
 
     member this.RemoveNuGetReference(groupName, packageName : PackageName) =
         let group = this.Groups.[groupName]

--- a/src/Paket.Core/Versioning/Requirements.fs
+++ b/src/Paket.Core/Versioning/Requirements.fs
@@ -922,6 +922,7 @@ type InstallSettings =
       Aliases : Map<string,string>
       CopyContentToOutputDirectory : CopyToOutputDirectorySettings option
       GenerateLoadScripts : bool option
+      GeneratePathProperty : bool option
       Simplify : bool option }
 
     static member Default =
@@ -940,6 +941,7 @@ type InstallSettings =
           CopyContentToOutputDirectory = None
           OmitContent = None
           GenerateLoadScripts = None
+          GeneratePathProperty = None
           Simplify = None }
 
     member this.ToString(groupSettings:InstallSettings,asLines) =
@@ -991,6 +993,10 @@ type InstallSettings =
               match this.GenerateLoadScripts with
               | Some true when groupSettings.GenerateLoadScripts <> this.GenerateLoadScripts -> yield "generate_load_scripts: true"
               | Some false when groupSettings.GenerateLoadScripts <> this.GenerateLoadScripts  -> yield "generate_load_scripts: false"
+              | _ -> ()
+              match this.GeneratePathProperty with
+              | Some true when groupSettings.GeneratePathProperty <> this.GeneratePathProperty -> yield "generate_path_property: true"
+              | Some false when groupSettings.GeneratePathProperty <> this.GeneratePathProperty -> yield "generate_path_property: false"
               | _ -> ()
               match this.Simplify with
               | Some false -> yield "simplify: false"
@@ -1100,6 +1106,11 @@ type InstallSettings =
                 | _ -> None
               GenerateLoadScripts =
                 match getPair "generate_load_scripts" with
+                | Some "on"  | Some "true" -> Some true
+                | Some "off" | Some "false" -> Some true
+                | _ -> None
+              GeneratePathProperty =
+                match getPair "generate_path_property" with
                 | Some "on"  | Some "true" -> Some true
                 | Some "off" | Some "false" -> Some true
                 | _ -> None

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -1682,6 +1682,17 @@ let ``parsing generate load scripts`` () =
             printfn "case %A expected %A got %A" case expectation result
         failwith "failed"
 
+let generatePathPropertyConfig = """
+generate_path_property: true
+source https://www.nuget.org/api/v2
+
+nuget FAKE
+"""
+
+[<Test>]
+let ``should read generate_path_property config``() =
+    let cfg = DependenciesFile.FromSource(generatePathPropertyConfig)
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.GeneratePathProperty |> shouldEqual (Some true)
 
 let configWithCLitTool = """
 source https://www.nuget.org/api/v2

--- a/tests/Paket.Tests/Lockfile/ParserSpecs.fs
+++ b/tests/Paket.Tests/Lockfile/ParserSpecs.fs
@@ -347,7 +347,7 @@ let frameworkRestricted' = """NUGET
       ReadOnlyCollectionInterfaces (1.0.0) - framework: >= net40
       System.Json (>= 4.0.20126.16343)
     FsControl (1.0.9)
-    FSharpPlus (0.0.4)
+    FSharpPlus (0.0.4) - generate_path_property: true
       FsControl (>= 1.0.9)
     LinqBridge (1.3.0) - import_targets: false, content: none, version_in_path: true, framework: >= net20 < net35, copy_content_to_output_dir: never
     ReadOnlyCollectionExtensions (1.2.0)
@@ -370,6 +370,8 @@ let ``should parse framework restricted lock file in new syntax``() =
 
     packages.[0].Settings.LicenseDownload |> shouldEqual (Some true)
 
+    packages.[2].Settings.GeneratePathProperty |> shouldEqual (Some true)
+
     packages.[3].Source |> shouldEqual PackageSources.DefaultNuGetSource
     packages.[3].Name |> shouldEqual (PackageName "LinqBridge")
     packages.[3].Version |> shouldEqual (SemVer.Parse "1.3.0")
@@ -383,6 +385,7 @@ let ``should parse framework restricted lock file in new syntax``() =
     packages.[3].Settings.IncludeVersionInPath |> shouldEqual (Some true)
     packages.[3].Settings.LicenseDownload |> shouldEqual None
     packages.[3].Settings.OmitContent |> shouldEqual (Some ContentCopySettings.Omit)
+    packages.[3].Settings.GeneratePathProperty |> shouldEqual None
 
     let dependencies4 =
         packages.[4].Dependencies |> Set.toList |> List.map (fun (_, _, r) -> r)
@@ -588,6 +591,7 @@ let groupsLockFile = """REDIRECTS: ON
 COPY-LOCAL: TRUE
 IMPORT-TARGETS: TRUE
 LICENSE-DOWNLOAD: TRUE
+GENERATE-PATH-PROPERTY: TRUE
 NUGET
   remote: "D:\code\temp with space"
     Castle.Windsor (2.1)
@@ -614,6 +618,7 @@ let ``should parse lock file with groups``() =
     lockFile1.Options.Settings.LicenseDownload |> shouldEqual (Some true)
     lockFile1.Options.Settings.CopyLocal |> shouldEqual (Some true)
     lockFile1.Options.Settings.ReferenceCondition |> shouldEqual None
+    lockFile1.Options.Settings.GeneratePathProperty |> shouldEqual (Some true)
 
     packages1.Head.Source.Url |> shouldEqual "D:\code\\temp with space"
     packages1.[0].Name |> shouldEqual (PackageName "Castle.Windsor")


### PR DESCRIPTION
This replicates the behavior of `<PackageReference GeneratePathProperty="true" />` in Paket. This is required in certain edge cases, such as when creating a source generator project that needs to reference third-party assemblies.

Tests have been added for verifying the option in the lockfile, paket.dependencies/paket.references files and to verify the output in the generated `paket.props` files.