### PR TITLE
Try adding some .NET 10 support

### DIFF
--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -152,6 +152,7 @@ type Net8WindowsVersion =
         | _ -> None
 
 type Net9WindowsVersion = Net8WindowsVersion
+type Net10WindowsVersion = Net9WindowsVersion
 
 [<RequireQualifiedAccess>]
 type Net5Os =
@@ -253,7 +254,8 @@ type Net8Os =
         |> Seq.tryFind(fun (k,_) -> s.StartsWith k)
         |> Option.map snd
          
-type Net9Os = Net8Os         
+type Net9Os = Net8Os 
+type Net10Os = Net9Os
 
 [<RequireQualifiedAccess>]
 /// The Framework version.
@@ -284,6 +286,7 @@ type FrameworkVersion =
     | V7
     | V8
     | V9
+    | V10
     override this.ToString() =
         match this with
         | V1        -> "v1.0"
@@ -311,6 +314,7 @@ type FrameworkVersion =
         | V7        -> "v7.0"
         | V8        -> "v8.0"
         | V9        -> "v9.0"
+        | V10       -> "v10.0"
 
     member this.ShortString() =
         match this with
@@ -339,6 +343,7 @@ type FrameworkVersion =
         | FrameworkVersion.V7 -> "7.0"
         | FrameworkVersion.V8 -> "8.0"
         | FrameworkVersion.V9 -> "9.0"
+        | FrameworkVersion.V10 -> "10.0"
 
     static member TryParse s =
         match s with
@@ -367,6 +372,7 @@ type FrameworkVersion =
         | "7" -> Some FrameworkVersion.V7
         | "8" -> Some FrameworkVersion.V8
         | "9" -> Some FrameworkVersion.V9
+        | "10" -> Some FrameworkVersion.V10
         | _ -> None
 
 [<RequireQualifiedAccess>]
@@ -808,6 +814,8 @@ type FrameworkIdentifier =
     | DotNet8Windows of Net8WindowsVersion
     | DotNet9WithOs of Net9Os
     | DotNet9Windows of Net9WindowsVersion
+    | DotNet10WithOs of Net10Os
+    | DotNet10Windows of Net10WindowsVersion
     | UAP of UAPVersion
     | DotNetStandard of DotNetStandardVersion
     | DotNetCoreApp of DotNetCoreAppVersion
@@ -831,6 +839,8 @@ type FrameworkIdentifier =
     override x.ToString() =
         match x with
         | DotNetFramework v -> "net" + v.ShortString()
+        | DotNet10WithOs o  -> "net10.0-" + o.ToString()
+        | DotNet10Windows v -> "net10.0-windows" + v.ToString()
         | DotNet9WithOs o  -> "net9.0-" + o.ToString()
         | DotNet9Windows v -> "net9.0-windows" + v.ToString()
         | DotNet8WithOs o  -> "net8.0-" + o.ToString()
@@ -946,6 +956,7 @@ type FrameworkIdentifier =
         | DotNetFramework FrameworkVersion.V7 -> [ DotNetFramework FrameworkVersion.V6 ]
         | DotNetFramework FrameworkVersion.V8 -> [ DotNetFramework FrameworkVersion.V7 ]
         | DotNetFramework FrameworkVersion.V9 -> [ DotNetFramework FrameworkVersion.V8 ]
+        | DotNetFramework FrameworkVersion.V10 -> [ DotNetFramework FrameworkVersion.V9 ]
         | DotNet5WithOs Net5Os.Android -> [ DotNetFramework FrameworkVersion.V5; MonoAndroid MonoAndroidVersion.V12 ]
         | DotNet5WithOs Net5Os.IOs -> [ DotNetFramework FrameworkVersion.V5; XamariniOS ]
         | DotNet5WithOs Net5Os.MacOs -> [ DotNetFramework FrameworkVersion.V5; XamarinMac ]
@@ -977,6 +988,11 @@ type FrameworkIdentifier =
         | DotNet9WithOs  Net8Os.MacOs   -> [ DotNetFramework FrameworkVersion.V9; XamarinMac ]
         | DotNet9WithOs  Net8Os.TvOs    -> [ DotNetFramework FrameworkVersion.V9; XamarinTV ]
         | DotNet9WithOs  Net8Os.WatchOs -> [ DotNetFramework FrameworkVersion.V9; XamarinWatch ]
+        | DotNet10WithOs  Net8Os.Android -> [ DotNetFramework FrameworkVersion.V10; MonoAndroid MonoAndroidVersion.V12 ]
+        | DotNet10WithOs  Net8Os.IOs     -> [ DotNetFramework FrameworkVersion.V10; XamariniOS ]
+        | DotNet10WithOs  Net8Os.MacOs   -> [ DotNetFramework FrameworkVersion.V10; XamarinMac ]
+        | DotNet10WithOs  Net8Os.TvOs    -> [ DotNetFramework FrameworkVersion.V10; XamarinTV ]
+        | DotNet10WithOs  Net8Os.WatchOs -> [ DotNetFramework FrameworkVersion.V10; XamarinWatch ]
         | DotNet6Windows Net6WindowsVersion.V7_0          -> [ DotNetFramework FrameworkVersion.V6 ]
         | DotNet6Windows Net6WindowsVersion.V8_0          -> [ DotNetFramework FrameworkVersion.V6; DotNet6Windows Net6WindowsVersion.V7_0 ]
         | DotNet6Windows Net6WindowsVersion.V10_0_17763_0 -> [ DotNetFramework FrameworkVersion.V6; DotNet6Windows Net6WindowsVersion.V8_0 ]
@@ -998,6 +1014,11 @@ type FrameworkIdentifier =
         | DotNet9Windows Net8WindowsVersion.V10_0_17763_0 -> [ DotNetFramework FrameworkVersion.V8; DotNet9Windows Net8WindowsVersion.V8_0]
         | DotNet9Windows Net8WindowsVersion.V10_0_18362_0 -> [ DotNetFramework FrameworkVersion.V8; DotNet9Windows Net8WindowsVersion.V10_0_17763_0 ]
         | DotNet9Windows Net8WindowsVersion.V10_0_19041_0 -> [ DotNetFramework FrameworkVersion.V8; DotNet9Windows Net8WindowsVersion.V10_0_18362_0 ]
+        | DotNet10Windows Net8WindowsVersion.V7_0          -> [ DotNetFramework FrameworkVersion.V8; ]
+        | DotNet10Windows Net8WindowsVersion.V8_0          -> [ DotNetFramework FrameworkVersion.V8; DotNet10Windows Net8WindowsVersion.V7_0]
+        | DotNet10Windows Net8WindowsVersion.V10_0_17763_0 -> [ DotNetFramework FrameworkVersion.V8; DotNet10Windows Net8WindowsVersion.V8_0]
+        | DotNet10Windows Net8WindowsVersion.V10_0_18362_0 -> [ DotNetFramework FrameworkVersion.V8; DotNet10Windows Net8WindowsVersion.V10_0_17763_0 ]
+        | DotNet10Windows Net8WindowsVersion.V10_0_19041_0 -> [ DotNetFramework FrameworkVersion.V8; DotNet10Windows Net8WindowsVersion.V10_0_18362_0 ]
         | DotNetStandard DotNetStandardVersion.V1_0 -> [  ]
         | DotNetStandard DotNetStandardVersion.V1_1 -> [ DotNetStandard DotNetStandardVersion.V1_0 ]
         | DotNetStandard DotNetStandardVersion.V1_2 -> [ DotNetStandard DotNetStandardVersion.V1_1 ]
@@ -1115,6 +1136,7 @@ module FrameworkDetection =
                     | Some "7" when dotnetVersionX = 7  -> tryParseSecondPart parts.[1]
                     | Some "8" when dotnetVersionX = 8  -> tryParseSecondPart parts.[1]
                     | Some "9" when dotnetVersionX = 9  -> tryParseSecondPart parts.[1]
+                    | Some "10" when dotnetVersionX = 10  -> tryParseSecondPart parts.[1]
                     | _ -> None
                 else
                     None
@@ -1130,6 +1152,7 @@ module FrameworkDetection =
                     | Some "7"  when dotnetVersionX = 7 -> tryParseVersion winVersionPart
                     | Some "8"  when dotnetVersionX = 8 -> tryParseVersion winVersionPart
                     | Some "9"  when dotnetVersionX = 9 -> tryParseVersion winVersionPart
+                    | Some "10"  when dotnetVersionX = 10 -> tryParseVersion winVersionPart
                     | _ -> None
                 else
                     None
@@ -1169,11 +1192,13 @@ module FrameworkDetection =
             // http://nugettoolsdev.azurewebsites.net/4.0.0/parse-framework?framework=.NETPortable%2CVersion%3Dv0.0%2CProfile%3DProfile2
             let result =
                 match path with
+                | MatchNetXDashWindows 10 Net10WindowsVersion.TryParse fm -> Some (DotNet10Windows fm)
                 | MatchNetXDashWindows 9 Net9WindowsVersion.TryParse fm -> Some (DotNet9Windows fm)
                 | MatchNetXDashWindows 8 Net8WindowsVersion.TryParse fm -> Some (DotNet8Windows fm)
                 | MatchNetXDashWindows 7 Net7WindowsVersion.TryParse fm -> Some (DotNet7Windows fm)
                 | MatchNetXDashWindows 6 Net6WindowsVersion.TryParse fm -> Some (DotNet6Windows fm)
                 | MatchNetXDashWindows 5 Net5WindowsVersion.TryParse fm -> Some (DotNet5Windows fm)
+                | MatchNetXDashOs 10 Net10Os.TryParse fm -> Some (DotNet10WithOs fm)
                 | MatchNetXDashOs 9 Net9Os.TryParse fm -> Some (DotNet9WithOs fm)
                 | MatchNetXDashOs 8 Net8Os.TryParse fm -> Some (DotNet8WithOs fm)
                 | MatchNetXDashOs 7 Net7Os.TryParse fm -> Some (DotNet7WithOs fm)
@@ -1560,6 +1585,7 @@ module KnownTargetProfiles =
         FrameworkVersion.V7
         FrameworkVersion.V8
         FrameworkVersion.V9
+        FrameworkVersion.V10
     ]
 
     let DotNetFrameworkIdentifiers =
@@ -1668,6 +1694,11 @@ module KnownTargetProfiles =
     let DotNet9WithOsProfiles = DotNet8WithOsProfiles
     let DotNet9WindowsVersions = DotNet8WindowsVersions
     let DotNet9WindowsProfiles = DotNet8WindowsProfiles
+
+    let DotNet10OperatingSystems = DotNet9OperatingSystems
+    let DotNet10WithOsProfiles = DotNet9WithOsProfiles
+    let DotNet10WindowsVersions = DotNet9WindowsVersions
+    let DotNet10WindowsProfiles = DotNet9WindowsProfiles
 
     let DotNetStandardVersions = [
         DotNetStandardVersion.V1_0
@@ -1840,6 +1871,8 @@ module KnownTargetProfiles =
 
     let AllDotNetProfiles =
        DotNetFrameworkProfiles @
+       DotNet10WithOsProfiles @
+       DotNet10WindowsProfiles @
        DotNet9WithOsProfiles @
        DotNet9WindowsProfiles @
        DotNet8WithOsProfiles @

--- a/src/Paket.Core/Versioning/PlatformMatching.fs
+++ b/src/Paket.Core/Versioning/PlatformMatching.fs
@@ -213,12 +213,15 @@ let getTargetCondition (target:TargetProfile) =
     match target with
     | TargetProfile.SinglePlatform(platform) ->
         match platform with
+        | DotNetFramework(FrameworkVersion.V10) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", "$(TargetFrameworkVersion) == 'v10.0'"
         | DotNetFramework(FrameworkVersion.V9) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", "$(TargetFrameworkVersion) == 'v9.0'"
         | DotNetFramework(FrameworkVersion.V8) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", "$(TargetFrameworkVersion) == 'v8.0'"
         | DotNetFramework(FrameworkVersion.V7) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", "$(TargetFrameworkVersion) == 'v7.0'"
         | DotNetFramework(FrameworkVersion.V6) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", "$(TargetFrameworkVersion) == 'v6.0'"
         | DotNetFramework(FrameworkVersion.V5) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", "$(TargetFrameworkVersion) == 'v5.0'"
         | DotNetFramework(version) ->"$(TargetFrameworkIdentifier) == '.NETFramework'", sprintf "$(TargetFrameworkVersion) == '%O'" version
+        | DotNet10WithOs(os) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", sprintf "($(TargetFrameworkVersion) == 'v10.0' And '$(TargetPlatformIdentifier)' == '%O')" os
+        | DotNet10Windows(version) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", sprintf "($(TargetFrameworkVersion) == 'v10.0' And '$(TargetPlatformIdentifier)' == 'Windows' And '$(TargetPlatformVersion)' == '%O')" version
         | DotNet9WithOs(os) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", sprintf "($(TargetFrameworkVersion) == 'v9.0' And '$(TargetPlatformIdentifier)' == '%O')" os
         | DotNet9Windows(version) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", sprintf "($(TargetFrameworkVersion) == 'v9.0' And '$(TargetPlatformIdentifier)' == 'Windows' And '$(TargetPlatformVersion)' == '%O')" version
         | DotNet8WithOs(os) ->"$(TargetFrameworkIdentifier) == '.NETCoreApp'", sprintf "($(TargetFrameworkVersion) == 'v8.0' And '$(TargetPlatformIdentifier)' == '%O')" os

--- a/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
+++ b/tests/Paket.Tests/DependenciesFile/ParserSpecs.fs
@@ -1288,6 +1288,21 @@ let ``should read config with .NET 9 target framework``() =
     |> getExplicitRestriction
     |> shouldEqual (FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V9)))
 
+let configNET10TargetFramework = """source https://www.nuget.org/api/v2
+
+framework: >= net10.0
+
+nuget System.Data.SQLite 1.0.98.1 content: none
+"""
+
+[<Test>]
+let ``should read config with .NET 10 target framework``() = 
+    let cfg = DependenciesFile.FromSource(configNET10TargetFramework)
+
+    cfg.Groups.[Constants.MainDependencyGroup].Options.Settings.FrameworkRestrictions
+    |> getExplicitRestriction
+    |> shouldEqual (FrameworkRestriction.AtLeast(FrameworkIdentifier.DotNetFramework(FrameworkVersion.V10)))
+
 let validFrameworks =
     let net40 = DotNetFramework(FrameworkVersion.V4)
     let net45 = DotNetFramework(FrameworkVersion.V4_5)

--- a/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
@@ -336,6 +336,30 @@ let ``Can detect a bunch of net9 platforms``() =
     failwith (String.concat "\n" errors)
 
 [<Test>]
+let ``Can detect a bunch of net10 platforms``() =
+  let testSet = [
+      "net10"                       , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNetFramework FrameworkVersion.V10)
+      "net1000"                     , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNetFramework FrameworkVersion.V10)
+      "net10.0-windows"             , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10Windows Net10WindowsVersion.V7_0)
+      "net10-windows"               , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10Windows Net10WindowsVersion.V7_0)
+      "net10.0-windows10.0.19041.0" , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10Windows Net10WindowsVersion.V10_0_19041_0)
+      "net10.0-windows10.0.19041"   , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10Windows Net10WindowsVersion.V10_0_19041_0)
+      "net10-windows10.0.19041"     , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10Windows Net10WindowsVersion.V10_0_19041_0)
+      "net1000-windows10.0.19041"   , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10Windows Net10WindowsVersion.V10_0_19041_0)
+      "net10.0-android30.0"         , TargetProfile.SinglePlatform (FrameworkIdentifier.DotNet10WithOs Net10Os.Android)
+    ]
+
+  let errors = [
+    for p, expected in testSet do
+      let parsed = (PlatformMatching.forceExtractPlatforms p).ToTargetProfile false
+      if parsed <> Some expected then
+        sprintf "%s resulted into %A instead of %A" p parsed expected
+  ]
+
+  if not (List.isEmpty errors) then
+    failwith (String.concat "\n" errors)
+
+[<Test>]
 let ``Can detect netstandard1.6``() =
     let p = PlatformMatching.forceExtractPlatforms "netstandard1.6"
     p.ToTargetProfile false |> shouldEqual (Some (TargetProfile.SinglePlatform (FrameworkIdentifier.DotNetStandard DotNetStandardVersion.V1_6)))


### PR DESCRIPTION
refs https://github.com/fsprojects/Paket/issues/4296

Basically cloned from the changes to add .NET 9 support, as I'm learning this as I go along.

As it stands the new tests don't quite work because the ```tryNormalizeVersion``` function is parsing the ```10``` in ```net10-windows``` into ```1.0``` instead of ```10.0```  - I haven't had time to look at that further.