### PR TITLE
Use NuGet.Configuration to get the path to the NuGet global…

### DIFF
--- a/src/Paket.Core/Common/Constants.fs
+++ b/src/Paket.Core/Common/Constants.fs
@@ -114,12 +114,9 @@ let GitRepoCacheFolder = Path.Combine(LocalRootForTempData,".paket","git","db")
 let [<Literal>] GlobalPackagesFolderEnvironmentKey = "NUGET_PACKAGES"
 
 let UserNuGetPackagesFolder =
-    getEnVar GlobalPackagesFolderEnvironmentKey
-    |> Option.map (fun path ->
-        path.Replace (Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
-    ) |> Option.defaultWith (fun _ ->
-        Path.Combine (LocalRootForTempData,".nuget","packages")
-    )
+
+    NuGet.Configuration.Settings.LoadDefaultSettings(null)
+    |> NuGet.Configuration.SettingsUtility.GetGlobalPackagesFolder
 
 /// The magic unpublished date is 1900-01-01T00:00:00
 let MagicUnlistingDate = DateTimeOffset(1900, 1, 1, 0, 0, 0, TimeSpan.FromHours(-8.)).DateTime


### PR DESCRIPTION
… packages folder

refs
https://github.com/fsprojects/Paket/issues/3853
https://github.com/fsprojects/Paket/issues/4209

I don't know the history of things in this area, I just hit https://github.com/fsprojects/Paket/issues/3853 when building some things that use paket on a system that has the ```globalPackagesFolder``` setting set to a custom location (on a different drive than the default user profile directory) and wondered if it would be possible to fix it by using the 'where is the cache folder' functionality in ```NuGet.Configuration``` rather than doing it locally (it contains the logic to look for  ```NUGET_PACKAGES```, then ```globalPackagesFolder```, then the regular defaults)