### PR TITLE
Parse native0.0 as valid TFM

### DIFF
--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -147,7 +147,7 @@ The supported framework identifiers include:
 * Mono for Android: `monoandroid{version}`
 * Mono for Mac: `monomac`
 * MonoTouch: `monotouch`
-* Native: `native` or `native({buildmode},{platform})`
+* Native: `native` or `native({buildmode},{platform})` or `native{version}`
 * Xamarin for Mac: `xamarinmac`
 * Xamarin for iOS: `xamarinios`
 * Xamarin for watchOS: `xamarinwatchos`

--- a/docs/content/dependencies-file.md
+++ b/docs/content/dependencies-file.md
@@ -147,7 +147,7 @@ The supported framework identifiers include:
 * Mono for Android: `monoandroid{version}`
 * Mono for Mac: `monomac`
 * MonoTouch: `monotouch`
-* Native: `native` or `native({buildmode},{platform})` or `native{version}`
+* Native: `native` or `native({buildmode},{platform})` or `native{major}` / `native{major}.{minor}` (e.g. `native0.0`)
 * Xamarin for Mac: `xamarinmac`
 * Xamarin for iOS: `xamarinios`
 * Xamarin for watchOS: `xamarinwatchos`

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -472,10 +472,11 @@ module InstallModel =
         // %s because 'native' uses subfolders...
         (trySscanf "lib/%A{tfm}/%s" p : (Tfm * string) option)
         |> Option.map (fun (l,path) ->
-            if l.Name = "native" && (match l.Platforms with
-                                     | [ FrameworkIdentifier.Native(NoBuildMode,NoPlatform,_) ] -> true
-                                     | _ -> false)
-            then
+            let isNative =
+                match l.Platforms with
+                | [ FrameworkIdentifier.Native(NoBuildMode,NoPlatform,_) ] -> true
+                | _ -> false
+            if l.Name.StartsWith("native") && isNative then
                 // We need some special logic to detect the platform
                 let path = path.ToLowerInvariant()
                 let newPlatform =

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -489,7 +489,8 @@ module InstallModel =
                     if path.Contains "/release/" then Release else
                     if path.Contains "/debug/" then Debug else
                     NoBuildMode
-                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,NativeVersion.None) ]}; File = p; Runtime = None }
+                let newVersion = NoVersion
+                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,newVersion) ]}; File = p; Runtime = None }
             else
             { Path = l; File = p; Runtime = None })
         |> Option.orElseWith (fun _ ->

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -489,7 +489,7 @@ module InstallModel =
                     if path.Contains "/release/" then Release else
                     if path.Contains "/debug/" then Debug else
                     NoBuildMode
-                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,NoVersion) ]}; File = p; Runtime = None }
+                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,NativeVersion.NoVersion) ]}; File = p; Runtime = None }
             else
             { Path = l; File = p; Runtime = None })
         |> Option.orElseWith (fun _ ->

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -489,7 +489,7 @@ module InstallModel =
                     if path.Contains "/release/" then Release else
                     if path.Contains "/debug/" then Debug else
                     NoBuildMode
-                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,NativeVersion.NoVersion) ]}; File = p; Runtime = None }
+                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,NativeVersion.None) ]}; File = p; Runtime = None }
             else
             { Path = l; File = p; Runtime = None })
         |> Option.orElseWith (fun _ ->

--- a/src/Paket.Core/PaketConfigFiles/InstallModel.fs
+++ b/src/Paket.Core/PaketConfigFiles/InstallModel.fs
@@ -472,7 +472,10 @@ module InstallModel =
         // %s because 'native' uses subfolders...
         (trySscanf "lib/%A{tfm}/%s" p : (Tfm * string) option)
         |> Option.map (fun (l,path) ->
-            if l.Name = "native" && l.Platforms = [ FrameworkIdentifier.Native(NoBuildMode,NoPlatform) ] then
+            if l.Name = "native" && (match l.Platforms with
+                                     | [ FrameworkIdentifier.Native(NoBuildMode,NoPlatform,_) ] -> true
+                                     | _ -> false)
+            then
                 // We need some special logic to detect the platform
                 let path = path.ToLowerInvariant()
                 let newPlatform =
@@ -486,7 +489,7 @@ module InstallModel =
                     if path.Contains "/release/" then Release else
                     if path.Contains "/debug/" then Debug else
                     NoBuildMode
-                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform) ]}; File = p; Runtime = None }
+                { Path = { l with Platforms = [ FrameworkIdentifier.Native(newBuildMode,newPlatform,NoVersion) ]}; File = p; Runtime = None }
             else
             { Path = l; File = p; Runtime = None })
         |> Option.orElseWith (fun _ ->

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -866,7 +866,7 @@ type FrameworkIdentifier =
     | MonoAndroid of MonoAndroidVersion
     | MonoTouch
     | MonoMac
-    | Native of BuildMode * Platform
+    | Native of BuildMode * Platform * NativeVersion
     | XamarinTV
     | XamarinWatch
     | XamariniOS
@@ -900,8 +900,8 @@ type FrameworkIdentifier =
         | MonoAndroid v -> "monoandroid" + v.ShortString()
         | MonoTouch -> "monotouch"
         | MonoMac -> "monomac"
-        | Native(BuildMode.NoBuildMode, Platform.NoPlatform) -> "native"
-        | Native(mode, platform) -> sprintf "native(%s,%s)" mode.AsString platform.AsString
+        | Native(BuildMode.NoBuildMode, Platform.NoPlatform, _) -> "native"
+        | Native(mode, platform, _) -> sprintf "native(%s,%s)" mode.AsString platform.AsString
         | XamarinTV -> "xamarintvos"
         | XamarinWatch -> "xamarinwatchos"
         | XamariniOS -> "xamarinios"
@@ -1316,15 +1316,15 @@ module FrameworkDetection =
                 | MatchTfm "xamarinwatchos" (allowVersions ["";"1"]) () -> Some XamarinWatch
                 | MatchTfm "xamarintvos" (allowVersions ["";"1"]) () -> Some XamarinTV
                 | MatchTfm "xamarinmac" (allowVersions ["";"1";"2"]) () -> Some XamarinMac
-                | "native/x86/debug" -> Some(Native(Debug,Win32))
-                | "native/x64/debug" -> Some(Native(Debug,X64))
-                | "native/arm/debug" -> Some(Native(Debug,Arm))
-                | "native/x86/release" -> Some(Native(Release,Win32))
-                | "native/x64/release" -> Some(Native(Release,X64))
-                | "native/arm/release" -> Some(Native(Release,Arm))
-                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32))
-                | "native/address-model-64" -> Some(Native(NoBuildMode,X64))
-                | "native" -> Some(Native(NoBuildMode,NoPlatform))
+                | "native/x86/debug" -> Some(Native(Debug,Win32,NoVersion))
+                | "native/x64/debug" -> Some(Native(Debug,X64,NoVersion))
+                | "native/arm/debug" -> Some(Native(Debug,Arm,NoVersion))
+                | "native/x86/release" -> Some(Native(Release,Win32,NoVersion))
+                | "native/x64/release" -> Some(Native(Release,X64,NoVersion))
+                | "native/arm/release" -> Some(Native(Release,Arm,NoVersion))
+                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NoVersion))
+                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NoVersion))
+                | MatchNative nv -> Some(Native(NoBuildMode,NoPlatform,nv))
                 | MatchTfm "sl" SilverlightVersion.TryParse fm -> Some (Silverlight fm)
                 | MatchTfms ["win"; "windows"; "netcore"; "winv"] parseWindows fm -> Some (Windows fm)
                 | "sl4-wp7" | "sl4-wp70" | "sl4-wp7.0" -> Some (WindowsPhone WindowsPhoneVersion.V7)
@@ -2018,16 +2018,16 @@ module KnownTargetProfiles =
        //[SinglePlatform (DNXCore FrameworkVersion.V5_0)]
 
     let AllNativeProfiles =
-        [ Native(NoBuildMode,NoPlatform)
-          Native(NoBuildMode,Win32)
-          Native(NoBuildMode,X64)
-          Native(NoBuildMode,Arm)
-          Native(Debug,Win32)
-          Native(Debug,Arm)
-          Native(Debug,X64)
-          Native(Release,Win32)
-          Native(Release,X64)
-          Native(Release,Arm)]
+        [ Native(NoBuildMode,NoPlatform,NoVersion)
+          Native(NoBuildMode,Win32,NoVersion)
+          Native(NoBuildMode,X64,NoVersion)
+          Native(NoBuildMode,Arm,NoVersion)
+          Native(Debug,Win32,NoVersion)
+          Native(Debug,Arm,NoVersion)
+          Native(Debug,X64,NoVersion)
+          Native(Release,Win32,NoVersion)
+          Native(Release,X64,NoVersion)
+          Native(Release,Arm,NoVersion)]
 
     let isSupportedProfile profile =
         match profile with

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -545,6 +545,7 @@ type DotNetCoreAppVersion =
         | _ when s = "3.1" -> Some DotNetCoreAppVersion.V3_1
         | _ -> None
 
+[<RequireQualifiedAccess>]
 type NativeVersion =
     | NoVersion
     | Major of major:int
@@ -1316,14 +1317,14 @@ module FrameworkDetection =
                 | MatchTfm "xamarinwatchos" (allowVersions ["";"1"]) () -> Some XamarinWatch
                 | MatchTfm "xamarintvos" (allowVersions ["";"1"]) () -> Some XamarinTV
                 | MatchTfm "xamarinmac" (allowVersions ["";"1";"2"]) () -> Some XamarinMac
-                | "native/x86/debug" -> Some(Native(Debug,Win32,NoVersion))
-                | "native/x64/debug" -> Some(Native(Debug,X64,NoVersion))
-                | "native/arm/debug" -> Some(Native(Debug,Arm,NoVersion))
-                | "native/x86/release" -> Some(Native(Release,Win32,NoVersion))
-                | "native/x64/release" -> Some(Native(Release,X64,NoVersion))
-                | "native/arm/release" -> Some(Native(Release,Arm,NoVersion))
-                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NoVersion))
-                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NoVersion))
+                | "native/x86/debug" -> Some(Native(Debug,Win32,NativeVersion.NoVersion))
+                | "native/x64/debug" -> Some(Native(Debug,X64,NativeVersion.NoVersion))
+                | "native/arm/debug" -> Some(Native(Debug,Arm,NativeVersion.NoVersion))
+                | "native/x86/release" -> Some(Native(Release,Win32,NativeVersion.NoVersion))
+                | "native/x64/release" -> Some(Native(Release,X64,NativeVersion.NoVersion))
+                | "native/arm/release" -> Some(Native(Release,Arm,NativeVersion.NoVersion))
+                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NativeVersion.NoVersion))
+                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NativeVersion.NoVersion))
                 | MatchNative nv -> Some(Native(NoBuildMode,NoPlatform,nv))
                 | MatchTfm "sl" SilverlightVersion.TryParse fm -> Some (Silverlight fm)
                 | MatchTfms ["win"; "windows"; "netcore"; "winv"] parseWindows fm -> Some (Windows fm)
@@ -2018,16 +2019,16 @@ module KnownTargetProfiles =
        //[SinglePlatform (DNXCore FrameworkVersion.V5_0)]
 
     let AllNativeProfiles =
-        [ Native(NoBuildMode,NoPlatform,NoVersion)
-          Native(NoBuildMode,Win32,NoVersion)
-          Native(NoBuildMode,X64,NoVersion)
-          Native(NoBuildMode,Arm,NoVersion)
-          Native(Debug,Win32,NoVersion)
-          Native(Debug,Arm,NoVersion)
-          Native(Debug,X64,NoVersion)
-          Native(Release,Win32,NoVersion)
-          Native(Release,X64,NoVersion)
-          Native(Release,Arm,NoVersion)]
+        [ Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion)
+          Native(NoBuildMode,Win32,NativeVersion.NoVersion)
+          Native(NoBuildMode,X64,NativeVersion.NoVersion)
+          Native(NoBuildMode,Arm,NativeVersion.NoVersion)
+          Native(Debug,Win32,NativeVersion.NoVersion)
+          Native(Debug,Arm,NativeVersion.NoVersion)
+          Native(Debug,X64,NativeVersion.NoVersion)
+          Native(Release,Win32,NativeVersion.NoVersion)
+          Native(Release,X64,NativeVersion.NoVersion)
+          Native(Release,Arm,NativeVersion.NoVersion)]
 
     let isSupportedProfile profile =
         match profile with

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -545,9 +545,8 @@ type DotNetCoreAppVersion =
         | _ when s = "3.1" -> Some DotNetCoreAppVersion.V3_1
         | _ -> None
 
-[<RequireQualifiedAccess>]
 type NativeVersion =
-    | None
+    | NoVersion
     | Major of major:int
     | MajorMinor of major:int * minor:int
 
@@ -1247,7 +1246,7 @@ module FrameworkDetection =
                 if not (s.StartsWith("native")) then
                     None
                 elif s.Length = 6 then
-                    Some NativeVersion.None
+                    Some NativeVersion.NoVersion
                 else
                     let versions = s.Substring 6 // expected # or #.#
                     let parts = versions.Split('.')
@@ -1317,14 +1316,14 @@ module FrameworkDetection =
                 | MatchTfm "xamarinwatchos" (allowVersions ["";"1"]) () -> Some XamarinWatch
                 | MatchTfm "xamarintvos" (allowVersions ["";"1"]) () -> Some XamarinTV
                 | MatchTfm "xamarinmac" (allowVersions ["";"1";"2"]) () -> Some XamarinMac
-                | "native/x86/debug" -> Some(Native(Debug,Win32,NativeVersion.None))
-                | "native/x64/debug" -> Some(Native(Debug,X64,NativeVersion.None))
-                | "native/arm/debug" -> Some(Native(Debug,Arm,NativeVersion.None))
-                | "native/x86/release" -> Some(Native(Release,Win32,NativeVersion.None))
-                | "native/x64/release" -> Some(Native(Release,X64,NativeVersion.None))
-                | "native/arm/release" -> Some(Native(Release,Arm,NativeVersion.None))
-                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NativeVersion.None))
-                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NativeVersion.None))
+                | "native/x86/debug" -> Some(Native(Debug,Win32,NoVersion))
+                | "native/x64/debug" -> Some(Native(Debug,X64,NoVersion))
+                | "native/arm/debug" -> Some(Native(Debug,Arm,NoVersion))
+                | "native/x86/release" -> Some(Native(Release,Win32,NoVersion))
+                | "native/x64/release" -> Some(Native(Release,X64,NoVersion))
+                | "native/arm/release" -> Some(Native(Release,Arm,NoVersion))
+                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NoVersion))
+                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NoVersion))
                 | MatchNative nv -> Some(Native(NoBuildMode,NoPlatform,nv))
                 | MatchTfm "sl" SilverlightVersion.TryParse fm -> Some (Silverlight fm)
                 | MatchTfms ["win"; "windows"; "netcore"; "winv"] parseWindows fm -> Some (Windows fm)
@@ -2019,16 +2018,16 @@ module KnownTargetProfiles =
        //[SinglePlatform (DNXCore FrameworkVersion.V5_0)]
 
     let AllNativeProfiles =
-        [ Native(NoBuildMode,NoPlatform,NativeVersion.None)
-          Native(NoBuildMode,Win32,NativeVersion.None)
-          Native(NoBuildMode,X64,NativeVersion.None)
-          Native(NoBuildMode,Arm,NativeVersion.None)
-          Native(Debug,Win32,NativeVersion.None)
-          Native(Debug,Arm,NativeVersion.None)
-          Native(Debug,X64,NativeVersion.None)
-          Native(Release,Win32,NativeVersion.None)
-          Native(Release,X64,NativeVersion.None)
-          Native(Release,Arm,NativeVersion.None)]
+        [ Native(NoBuildMode,NoPlatform,NoVersion)
+          Native(NoBuildMode,Win32,NoVersion)
+          Native(NoBuildMode,X64,NoVersion)
+          Native(NoBuildMode,Arm,NoVersion)
+          Native(Debug,Win32,NoVersion)
+          Native(Debug,Arm,NoVersion)
+          Native(Debug,X64,NoVersion)
+          Native(Release,Win32,NoVersion)
+          Native(Release,X64,NoVersion)
+          Native(Release,Arm,NoVersion)]
 
     let isSupportedProfile profile =
         match profile with

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -1242,6 +1242,30 @@ module FrameworkDetection =
                     |> Option.bind FrameworkVersion.TryParse
                 else
                     None
+            let (|MatchNative|_|) (s:string) =
+                if not (s.StartsWith("native")) then
+                    None
+                elif s.Length = 6 then
+                    Some NativeVersion.NoVersion
+                else
+                    let versions = s.Substring 6 // expected # or #.#
+                    let parts = versions.Split('.')
+
+                    match parts with
+                    | [| majorPart |] ->
+                        match Int32.TryParse majorPart with
+                        | true, major -> Some (NativeVersion.Major major)
+                        | false, _ -> None
+
+                    | [| majorPart; minorPart |] ->
+                        match Int32.TryParse majorPart, Int32.TryParse minorPart with
+                        | (true, major), (true, minor) ->
+                            Some (NativeVersion.MajorMinor (major, minor))
+                        | _ ->
+                            None
+
+                    | _ ->
+                        None
             let Bind f = (fun _ -> f)
             let parseWindows tfmStart v =
                 match tfmStart with

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -545,6 +545,11 @@ type DotNetCoreAppVersion =
         | _ when s = "3.1" -> Some DotNetCoreAppVersion.V3_1
         | _ -> None
 
+type NativeVersion =
+    | NoVersion
+    | Major of major:int
+    | MajorMinor of major:int * minor:int
+
 [<RequireQualifiedAccess>]
 /// The Framework version.
 // Each time a new version is added NuGetPackageCache.CurrentCacheVersion should be bumped.

--- a/src/Paket.Core/Versioning/FrameworkHandling.fs
+++ b/src/Paket.Core/Versioning/FrameworkHandling.fs
@@ -547,7 +547,7 @@ type DotNetCoreAppVersion =
 
 [<RequireQualifiedAccess>]
 type NativeVersion =
-    | NoVersion
+    | None
     | Major of major:int
     | MajorMinor of major:int * minor:int
 
@@ -1247,7 +1247,7 @@ module FrameworkDetection =
                 if not (s.StartsWith("native")) then
                     None
                 elif s.Length = 6 then
-                    Some NativeVersion.NoVersion
+                    Some NativeVersion.None
                 else
                     let versions = s.Substring 6 // expected # or #.#
                     let parts = versions.Split('.')
@@ -1317,14 +1317,14 @@ module FrameworkDetection =
                 | MatchTfm "xamarinwatchos" (allowVersions ["";"1"]) () -> Some XamarinWatch
                 | MatchTfm "xamarintvos" (allowVersions ["";"1"]) () -> Some XamarinTV
                 | MatchTfm "xamarinmac" (allowVersions ["";"1";"2"]) () -> Some XamarinMac
-                | "native/x86/debug" -> Some(Native(Debug,Win32,NativeVersion.NoVersion))
-                | "native/x64/debug" -> Some(Native(Debug,X64,NativeVersion.NoVersion))
-                | "native/arm/debug" -> Some(Native(Debug,Arm,NativeVersion.NoVersion))
-                | "native/x86/release" -> Some(Native(Release,Win32,NativeVersion.NoVersion))
-                | "native/x64/release" -> Some(Native(Release,X64,NativeVersion.NoVersion))
-                | "native/arm/release" -> Some(Native(Release,Arm,NativeVersion.NoVersion))
-                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NativeVersion.NoVersion))
-                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NativeVersion.NoVersion))
+                | "native/x86/debug" -> Some(Native(Debug,Win32,NativeVersion.None))
+                | "native/x64/debug" -> Some(Native(Debug,X64,NativeVersion.None))
+                | "native/arm/debug" -> Some(Native(Debug,Arm,NativeVersion.None))
+                | "native/x86/release" -> Some(Native(Release,Win32,NativeVersion.None))
+                | "native/x64/release" -> Some(Native(Release,X64,NativeVersion.None))
+                | "native/arm/release" -> Some(Native(Release,Arm,NativeVersion.None))
+                | "native/address-model-32" -> Some(Native(NoBuildMode,Win32,NativeVersion.None))
+                | "native/address-model-64" -> Some(Native(NoBuildMode,X64,NativeVersion.None))
                 | MatchNative nv -> Some(Native(NoBuildMode,NoPlatform,nv))
                 | MatchTfm "sl" SilverlightVersion.TryParse fm -> Some (Silverlight fm)
                 | MatchTfms ["win"; "windows"; "netcore"; "winv"] parseWindows fm -> Some (Windows fm)
@@ -2019,16 +2019,16 @@ module KnownTargetProfiles =
        //[SinglePlatform (DNXCore FrameworkVersion.V5_0)]
 
     let AllNativeProfiles =
-        [ Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion)
-          Native(NoBuildMode,Win32,NativeVersion.NoVersion)
-          Native(NoBuildMode,X64,NativeVersion.NoVersion)
-          Native(NoBuildMode,Arm,NativeVersion.NoVersion)
-          Native(Debug,Win32,NativeVersion.NoVersion)
-          Native(Debug,Arm,NativeVersion.NoVersion)
-          Native(Debug,X64,NativeVersion.NoVersion)
-          Native(Release,Win32,NativeVersion.NoVersion)
-          Native(Release,X64,NativeVersion.NoVersion)
-          Native(Release,Arm,NativeVersion.NoVersion)]
+        [ Native(NoBuildMode,NoPlatform,NativeVersion.None)
+          Native(NoBuildMode,Win32,NativeVersion.None)
+          Native(NoBuildMode,X64,NativeVersion.None)
+          Native(NoBuildMode,Arm,NativeVersion.None)
+          Native(Debug,Win32,NativeVersion.None)
+          Native(Debug,Arm,NativeVersion.None)
+          Native(Debug,X64,NativeVersion.None)
+          Native(Release,Win32,NativeVersion.None)
+          Native(Release,X64,NativeVersion.None)
+          Native(Release,Arm,NativeVersion.None)]
 
     let isSupportedProfile profile =
         match profile with

--- a/src/Paket.Core/Versioning/PlatformMatching.fs
+++ b/src/Paket.Core/Versioning/PlatformMatching.fs
@@ -257,9 +257,9 @@ let getTargetCondition (target:TargetProfile) =
         | XamarinWatch -> "$(TargetFrameworkIdentifier) == 'Xamarin.watchOS'", ""
         | UAP(version) -> "$(TargetFrameworkIdentifier) == '.NETCore'", sprintf "$(TargetFrameworkVersion) == '%O'" version.NetCoreVersion
         | XamarinMac -> "$(TargetFrameworkIdentifier) == 'Xamarin.Mac'", ""
-        | Native(NoBuildMode,NoPlatform) -> "true", ""
-        | Native(NoBuildMode,bits) -> (sprintf "'$(Platform)'=='%s'" bits.AsString), ""
-        | Native(profile,bits) -> (sprintf "'$(Configuration)|$(Platform)'=='%s|%s'" profile.AsString bits.AsString), ""
+        | Native(NoBuildMode,NoPlatform,_) -> "true", ""
+        | Native(NoBuildMode,bits,_) -> (sprintf "'$(Platform)'=='%s'" bits.AsString), ""
+        | Native(profile,bits,_) -> (sprintf "'$(Configuration)|$(Platform)'=='%s|%s'" profile.AsString bits.AsString), ""
         | Tizen version ->"$(TargetFrameworkIdentifier) == 'Tizen'", sprintf "$(TargetFrameworkVersion) == '%O'" version
         | XCode version ->"$(TargetFrameworkIdentifier) == 'XCode'", sprintf "$(TargetFrameworkVersion) == '%O'" version
         | Unsupported s -> "", ""
@@ -288,12 +288,15 @@ let getCondition (referenceCondition:string option) (targets : TargetProfile Set
         |> CheckIfFullyInGroupS "WindowsPhone" (function TargetProfile.SinglePlatform (WindowsPhone _) -> true | _ -> false)
 
     let conditions =
-        if targets.Count = 1 && targets |> Set.minElement = TargetProfile.SinglePlatform(Native(NoBuildMode,NoPlatform)) then
+        if targets.Count = 1 && (match targets |> Set.minElement with
+                                 | TargetProfile.SinglePlatform(Native(NoBuildMode,NoPlatform,_)) -> true
+                                 | _ -> false)
+        then
             targets
         else
             targets
             |> Set.filter (function
-                           | TargetProfile.SinglePlatform(Native(NoBuildMode,NoPlatform)) -> false
+                           | TargetProfile.SinglePlatform(Native(NoBuildMode,NoPlatform,_)) -> false
                            | _ -> true)
         |> Seq.map getTargetCondition
         |> Seq.filter (fun (_, v) -> v <> "false")

--- a/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
+++ b/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
@@ -240,10 +240,10 @@ let ``Simplify <|| (&& (net452) (native)) (native)>`` () =
         (FrameworkRestriction.Or[
             FrameworkRestriction.And[
                 FrameworkRestriction.Exactly (DotNetFramework FrameworkVersion.V4_5_2)
-                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.None))]
-            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.None))])
+                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion))]
+            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion))])
     toSimplify
-    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.None)))
+    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion)))
 
 [<Test>]
 let ``Simplify (>=net20) && (>=net20)``() = 

--- a/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
+++ b/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
@@ -240,10 +240,10 @@ let ``Simplify <|| (&& (net452) (native)) (native)>`` () =
         (FrameworkRestriction.Or[
             FrameworkRestriction.And[
                 FrameworkRestriction.Exactly (DotNetFramework FrameworkVersion.V4_5_2)
-                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion))]
-            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion))])
+                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))]
+            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))])
     toSimplify
-    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion)))
+    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion)))
 
 [<Test>]
 let ``Simplify (>=net20) && (>=net20)``() = 

--- a/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
+++ b/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
@@ -240,10 +240,10 @@ let ``Simplify <|| (&& (net452) (native)) (native)>`` () =
         (FrameworkRestriction.Or[
             FrameworkRestriction.And[
                 FrameworkRestriction.Exactly (DotNetFramework FrameworkVersion.V4_5_2)
-                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))]
-            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))])
+                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.None))]
+            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.None))])
     toSimplify
-    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion)))
+    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NativeVersion.None)))
 
 [<Test>]
 let ``Simplify (>=net20) && (>=net20)``() = 

--- a/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
+++ b/tests/Paket.Tests/Versioning/FrameworkRestrictionTests.fs
@@ -240,10 +240,10 @@ let ``Simplify <|| (&& (net452) (native)) (native)>`` () =
         (FrameworkRestriction.Or[
             FrameworkRestriction.And[
                 FrameworkRestriction.Exactly (DotNetFramework FrameworkVersion.V4_5_2)
-                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform))]
-            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform))])
+                FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion))]
+            FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion))])
     toSimplify
-    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform)))
+    |> shouldEqual (FrameworkRestriction.Exactly (Native(NoBuildMode,NoPlatform,NoVersion)))
 
 [<Test>]
 let ``Simplify (>=net20) && (>=net20)``() = 

--- a/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
+++ b/tests/Paket.Tests/Versioning/PlatformMatchingSpecs.fs
@@ -72,6 +72,13 @@ let ``Can detect MonoTouch0.0``() =
     p.ToTargetProfile false |> shouldEqual (Some (TargetProfile.SinglePlatform FrameworkIdentifier.MonoTouch))
 
 [<Test>]
+let ``Can detect native0.0``() =
+    let p = PlatformMatching.extractPlatforms false "native0.0"
+    p |> Option.isSome |> shouldEqual true
+    p.Value.Platforms
+    |> shouldEqual [FrameworkIdentifier.Native(BuildMode.NoBuildMode, Platform.NoPlatform, NativeVersion.MajorMinor(0,0))]
+
+[<Test>]
 let ``Can detect netcore1.0``() =
     // Currently required for backwards compat (2017-08-20), as we wrote these incorrectly in previous versions.
     let p = PlatformMatching.forceExtractPlatforms "netcore1.0"

--- a/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
+++ b/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
@@ -116,8 +116,8 @@ let ``should filter >= net20 < net40 and >= net40``() =
 
 [<Test>]
 let ``should not filter native, net452``() =
-    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion))])
-    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion)))
+    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))])
+    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion)))
 
     filterRestrictions l1 l2
-    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion))))
+    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))))

--- a/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
+++ b/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
@@ -116,8 +116,8 @@ let ``should filter >= net20 < net40 and >= net40``() =
 
 [<Test>]
 let ``should not filter native, net452``() =
-    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.None))])
-    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.None)))
+    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion))])
+    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion)))
 
     filterRestrictions l1 l2
-    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.None))))
+    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion))))

--- a/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
+++ b/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
@@ -116,8 +116,8 @@ let ``should filter >= net20 < net40 and >= net40``() =
 
 [<Test>]
 let ``should not filter native, net452``() =
-    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))])
-    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion)))
+    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.None))])
+    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.None)))
 
     filterRestrictions l1 l2
-    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.NoVersion))))
+    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NativeVersion.None))))

--- a/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
+++ b/tests/Paket.Tests/Versioning/RestrictionFilterSpecs.fs
@@ -116,8 +116,8 @@ let ``should filter >= net20 < net40 and >= net40``() =
 
 [<Test>]
 let ``should not filter native, net452``() =
-    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform))])
-    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform)))
+    let l1 = ExplicitRestriction (FrameworkRestriction.Or [FrameworkRestriction.Exactly(DotNetFramework(FrameworkVersion.V4_5_2)); FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion))])
+    let l2 = ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion)))
 
     filterRestrictions l1 l2
-    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform))))
+    |> shouldEqual (ExplicitRestriction (FrameworkRestriction.Exactly(Native(NoBuildMode,NoPlatform,NoVersion))))


### PR DESCRIPTION
It seems many nupkg's (particularly Microsoft ones) are now including the TFM `native0.0`, not just plain `native`. A few listed by popularity are:
* [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk#dependencies-body-tab)
* [Microsoft.UI.Xaml](https://www.nuget.org/packages/Microsoft.UI.Xaml#dependencies-body-tab)
* [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2#dependencies-body-tab)
* [Microsoft.ML.OnnxRuntime](https://www.nuget.org/packages/Microsoft.ML.OnnxRuntime#dependencies-body-tab)
* [Win2D.uwp](https://www.nuget.org/packages/Win2D.uwp#dependencies-body-tab)

Within `FrameworkHandling` added new parsing function to handle `native`, `native#`, or `native#.#`. We could potentially just ignore the version string after native, since no one seems to really know how to handle it and there are no real docs. But I figured we could capture it if needed. This is in new union `NativeVersion`. The base case as used in old code primarily going to be `NoVersion`. Changed any existing callsites matching particular Native() types to ignore NativeVersion.

This should then remove the Paket warning complaining that nupkg authors are using an unknown TFM:
```
Could not detect any platforms from 'native0.0' in '/home/user/.nuget/packages/microsoft.net.test.sdk/18.0.1/microsoft.net.test.sdk.nuspec', please tell the package authors
```
`Microsoft.NET.Test.Sdk` is a pretty popular package, and likely everyone is using it who is performing even rudimentary unit tests.

Attempts to resolve: https://github.com/fsprojects/Paket/issues/4318