### PR TITLE
Remove msbuild.exe lookup to fix build crash after RoslynTools.MSBuild removal #4002

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -482,7 +482,6 @@ let fakeStartInfo fsiargs script workingDirectory args environmentVars =
             info.EnvironmentVariables.[k] <- v
         for (k, v) in environmentVars do
             setVar k v
-        setVar "MSBuild" msBuildExe
         setVar "GIT" Git.CommandHelper.gitPath
         setVar "FSI" fsiPath)
 


### PR DESCRIPTION
This fixes "System.IO.DirectoryNotFoundException: Could not find a part of the path '~\packages\build\RoslynTools.MSBuild\tools\msbuild\MSBuild.exe'." error after removal of RoslynTools.MSBuild package.

Partial (?) fix for #4002 