### PR TITLE
[repo-assist] CI: enable scriptgen integration test suite as a required Linux job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,26 @@ jobs:
           export ${{ matrix.skip_env }}
           ./build.sh BuildPackage < /dev/null
 
+  linux-integration-scriptgen:
+    name: Linux (integration tests, scriptgen)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Install Mono
+        run: sudo apt-get update && sudo apt-get install --yes mono-complete
+      - name: Install build SDK and integration test runtime
+        run: |
+          curl --fail --silent --show-error --location https://dot.net/v1/dotnet-install.sh --output /tmp/dotnet-install.sh
+          bash /tmp/dotnet-install.sh --version 9.0.309 --install-dir "$HOME/.local/share/dotnetcore"
+          bash /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir "$HOME/.local/share/dotnetcore"
+      - name: Run scriptgen integration tests
+        env:
+          EnableWindowsTargeting: true
+        run: ./build.sh QuickIntegrationTests < /dev/null
+
   windows:
     name: Windows (.NET)
     runs-on: windows-latest


### PR DESCRIPTION
Adds a new linux-integration-scriptgen job that runs the existing
QuickIntegrationTests build target (TestCategory=scriptgen), the
smallest known-green slice of the Linux integration suite. Verified
locally: build -> publish -> dotnet test --filter TestCategory=scriptgen
passes 12/12 (1 skipped).

This is a first step toward issue #4346's recovery plan; the remaining
13 net9 and 3 net461 failures still need triage per that issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
