### PR TITLE
[repo-assist] Cache NuGet packages in CI to speed up builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('paket.lock', 'paket.dependencies', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Install Mono
         run: sudo apt-get update && sudo apt-get install --yes mono-complete
       - name: Install build SDK and integration test runtime
@@ -54,6 +63,15 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('paket.lock', 'paket.dependencies', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Build
         run: .\build.cmd BuildPackage
       - name: Upload build artifacts


### PR DESCRIPTION
Add actions/cache for ~/.nuget/packages and the paket packages
folder, keyed on paket.lock/paket.dependencies/global.json, for both
the Linux and Windows CI jobs. Every CI run currently performs a full
package restore from scratch; caching should meaningfully reduce
restore time on cache hits without changing build behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
