### PR TITLE
build: upgrade to .NET 10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "paket": {
-      "version": "9.0.2",
+      "version": "10.3.1",
       "commands": [
         "paket"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install build SDK and integration test runtime
         run: |
           curl --fail --silent --show-error --location https://dot.net/v1/dotnet-install.sh --output /tmp/dotnet-install.sh
-          bash /tmp/dotnet-install.sh --version 9.0.309 --install-dir "$HOME/.local/share/dotnetcore"
+          bash /tmp/dotnet-install.sh --version 10.0.400 --install-dir "$HOME/.local/share/dotnetcore"
           bash /tmp/dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir "$HOME/.local/share/dotnetcore"
       - name: Build and test
         env:

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -241,8 +241,9 @@
 				<OmitContent Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 7">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[6])</OmitContent>
 				<ImportTargets Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 8">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[7])</ImportTargets>
 				<Aliases Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 9">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[8])</Aliases>
+				<ReferenceCondition Condition="%(PaketReferencesFileLinesInfo.Splits) &gt;= 10">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[9])</ReferenceCondition>
 			</PaketReferencesFileLinesInfo>
-			<PackageReference Condition=" '$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct' " Include="%(PaketReferencesFileLinesInfo.PackageName)">
+			<PackageReference Condition=" ('$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct') AND ('%(PaketReferencesFileLinesInfo.ReferenceCondition)' == 'true' Or $(%(PaketReferencesFileLinesInfo.ReferenceCondition)) == 'true')" Include="%(PaketReferencesFileLinesInfo.PackageName)">
 				<Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
 				<PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
 				<ExcludeAssets Condition=" %(PaketReferencesFileLinesInfo.CopyLocal) == 'false' or %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
@@ -251,10 +252,8 @@
 				<Aliases Condition=" %(PaketReferencesFileLinesInfo.Aliases) != ''">%(PaketReferencesFileLinesInfo.Aliases)</Aliases>
 				<Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
 				<AllowExplicitVersion>true</AllowExplicitVersion>
-
 			</PackageReference>
-
-			<PackageVersion Include="%(PaketReferencesFileLinesInfo.PackageName)">
+			<PackageVersion Condition="('$(ManagePackageVersionsCentrally)' != 'true' Or '%(PaketReferencesFileLinesInfo.Reference)' == 'Direct') AND ('%(PaketReferencesFileLinesInfo.ReferenceCondition)' == 'true' Or $(%(PaketReferencesFileLinesInfo.ReferenceCondition)) == 'true')" Include="%(PaketReferencesFileLinesInfo.PackageName)">
 				<Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
 			</PackageVersion>
 		</ItemGroup>
@@ -319,7 +318,17 @@
 		</ItemGroup>
 
 		<Error Text="Error Because of PAKET_ERROR_ON_MSBUILD_EXEC (not calling fix-nuspecs)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' " />
-		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' />
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) show-conditions -s' ConsoleToMSBuild="true" StandardOutputImportance="low">
+			<Output TaskParameter="ConsoleOutput" ItemName="_ConditionProperties"/>
+		</Exec>
+		<ItemGroup>
+			<_DefinedConditionProperties Include="@(_ConditionProperties)" Condition="$(%(Identity)) == 'true'"/>
+		</ItemGroup>
+		<PropertyGroup>
+			<_ConditionsParameter></_ConditionsParameter>
+			<_ConditionsParameter Condition="@(_DefinedConditionProperties) != ''">--conditions @(_DefinedConditionProperties)</_ConditionsParameter>
+		</PropertyGroup>
+		<Exec Condition="@(_NuspecFiles) != ''" Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" $(_ConditionsParameter)' />
 		<Error Condition="@(_NuspecFiles) == ''" Text='Could not find nuspec files in "$(AdjustedNuspecOutputPath)" (Version: "$(PackageVersion)"), therefore we cannot call "paket fix-nuspecs" and have to error out!' />
 
 		<ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ Commands are defined in `src/Paket/Commands.fs` using Argu. Each command has cor
 ## Target Frameworks
 
 - **Paket.Core**: `net461` and `netstandard2.0`
-- **Paket CLI**: `net461` and `net9`
-- **Tests**: `net461` and `net9` (some tests may be framework-specific via `#if` directives)
+- **Paket CLI**: `net461` and `net10.0`
+- **Tests**: `net461` and `net10.0` (some tests may be framework-specific via `#if` directives)
 
 ## Conditional Compilation
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <TargetFrameworkRootPath>$(MSBuildThisFileDirectory)packages\build\0x53A.ReferenceAssemblies.Paket\tools\framework</TargetFrameworkRootPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!--
+    NU1510: PackageReference 'xxx' will not be pruned. Raised by the .NET 10 SDK for framework-provided packages; here they come from Paket's transitive resolution of NETStandard.Library, not from hand-written references.
     NU1902: Package 'xxx' X.Y.Z has a known moderate severity vulnerability, https://URI
     NU1903: Package 'xxx' X.Y.Z has a known high severity vulnerability, https://URI
     NU1904: Package 'xxx' X.Y.Z has a known critical severity vulnerability, https://URI
@@ -10,7 +11,7 @@
     FS0040: This and other recursive references to the object(s) being defined will be checked for initialization-soundness at runtime through the use of a delayed reference. This is because you are defining one or more recursive objects, rather than recursive functions.
     FS0044: This construct is deprecated.
     -->
-   <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902;NU1903;NU1904;FS0086;FS0040;FS0044</WarningsNotAsErrors>
+   <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1510;NU1902;NU1903;NU1904;FS0086;FS0040;FS0044</WarningsNotAsErrors>
   </PropertyGroup>
   <Import Project="$(PackageReleaseNotesFile)" Condition=" Exists('$(PackageReleaseNotesFile)') " />
 </Project>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 11.0.0-alpha001 - 2026-08-30
+* Upgrade to .NET 10: SDK 10.0.400 and target frameworks from net9 to net10.0. The `paket` .NET tool now requires the .NET 10 runtime; the merged `paket.exe` still targets net461.
+
 #### 10.3.1 - 2026-01-20
 * REVERT: https://github.com/fsprojects/Paket/pull/4284
 

--- a/build.fsx
+++ b/build.fsx
@@ -67,10 +67,10 @@ let mutable dotnetExePath = "dotnet"
 
 let buildDir = "bin"
 let buildDirNet461 = buildDir @@ "net461"
-let buildDirNetCore = buildDir @@ "net9"
+let buildDirNetCore = buildDir @@ "net10.0"
 let buildDirBootstrapper = "bin_bootstrapper"
 let buildDirBootstrapperNet461 = buildDirBootstrapper @@ "net461"
-let buildDirBootstrapperNetCore = buildDirBootstrapper @@ "net9"
+let buildDirBootstrapperNetCore = buildDirBootstrapper @@ "net10.0"
 let tempDir = "temp"
 let buildMergedDir = buildDir @@ "merged"
 let paketFile = buildMergedDir @@ "paket.exe"
@@ -199,7 +199,7 @@ Target "Publish" (fun _ ->
     DotNetCli.Publish (fun c ->
         { c with
             Project = "src/Paket"
-            Framework = "net9"
+            Framework = "net10.0"
             Output = FullName (currentDirectory </> buildDirNetCore)
             ToolPath = dotnetExePath
             AdditionalArgs = publishArgs
@@ -217,7 +217,7 @@ Target "Publish" (fun _ ->
     DotNetCli.Publish (fun c ->
         { c with
             Project = "src/Paket.Bootstrapper"
-            Framework = "net9"
+            Framework = "net10.0"
             Output = FullName (currentDirectory </> buildDirBootstrapperNetCore)
             ToolPath = dotnetExePath
             AdditionalArgs = publishArgs
@@ -355,7 +355,7 @@ Target "RunIntegrationTestsNetCore" (fun _ ->
     DotNetCli.Test (fun c ->
         { c with
             Project = "integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj"
-            Framework = "net9"
+            Framework = "net10.0"
             AdditionalArgs =
               [ "--filter"; (if testSuiteFilterFlakyTests then "TestCategory=Flaky" else "TestCategory!=Flaky")
                 sprintf "--logger:trx;LogFileName=%s" ("tests_result/netcore/Paket.IntegrationTests/TestResult.trx" |> Path.GetFullPath) ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.309",
+      "version": "10.0.400",
       "rollForward": "latestMinor"
     }
 }

--- a/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
+++ b/integrationtests/Paket.IntegrationTests/Paket.IntegrationTests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net9</TargetFrameworks>
+    <TargetFrameworks>net461;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <DefineConstants Condition=" '$(TargetFramework)' != 'net461'">PAKET_NETCORE;NO_UNIT_PLATFORMATTRIBUTE;TESTSUITE_KNOWN_FAILURE_DOTNETCORE_3005;FAKE_NETSTANDARD_API;@(DefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/integrationtests/Paket.IntegrationTests/TestHelper.fs
+++ b/integrationtests/Paket.IntegrationTests/TestHelper.fs
@@ -21,14 +21,14 @@ let dotnetToolPath =
 
 let paketToolPath =
 #if PAKET_NETCORE
-    dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../bin/net9/paket.dll")
+    dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../bin/net10.0/paket.dll")
 #else
     "", FullName(__SOURCE_DIRECTORY__ + "../../../bin/net461/paket.exe")
 #endif
 
 let paketBootstrapperToolPath =
 #if PAKET_NETCORE
-    dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../bin_bootstrapper/net9/paket.bootstrapper.dll")
+    dotnetToolPath, FullName(__SOURCE_DIRECTORY__ + "../../../bin_bootstrapper/net10.0/paket.bootstrapper.dll")
 #else
     "", FullName(__SOURCE_DIRECTORY__ + "../../../bin_bootstrapper/net461/paket.bootstrapper.exe")
 #endif

--- a/src/LockFileComparer/LockFileComparer.fsproj
+++ b/src/LockFileComparer/LockFileComparer.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
+++ b/src/Paket.Bootstrapper/Paket.Bootstrapper.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net9</TargetFrameworks>
+    <TargetFrameworks>net461;net10.0</TargetFrameworks>
     <StartupObject>Paket.Bootstrapper.Program</StartupObject>
     <AssemblyName>paket.bootstrapper</AssemblyName>
     <ToolCommandName>paketbootstrapper</ToolCommandName>

--- a/src/Paket.Core/Versioning/SemVer.fs
+++ b/src/Paket.Core/Versioning/SemVer.fs
@@ -267,10 +267,10 @@ module SemVer =
                 /// matches over list of the version fragments *and* delimiters
                 let major, minor, patch, revision, suffix =
                     match fragments with
-                    | Int M::"."::Int m::"."::Int p::"."::Big b::tail -> M, m, p, b, tail
-                    | Int M::"."::Int m::"."::Int p::tail -> M, m, p, 0I, tail
-                    | Int M::"."::Int m::tail -> M, m, 0, 0I, tail
-                    | Int M::tail -> M, 0, 0, 0I, tail
+                    | Int ma::"."::Int m::"."::Int p::"."::Big b::tail -> ma, m, p, b, tail
+                    | Int ma::"."::Int m::"."::Int p::tail -> ma, m, p, 0I, tail
+                    | Int ma::"."::Int m::tail -> ma, m, 0, 0I, tail
+                    | Int ma::tail -> ma, 0, 0, 0I, tail
                     | _ -> raise(ArgumentException("SemVer.Parse", "version"))
                     //this is expected to fail, for now :/
                     //| [text] -> 0, 0, 0, 0I, [text] 

--- a/src/Paket/Paket.fsproj
+++ b/src/Paket/Paket.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;net9</TargetFrameworks>
+    <TargetFrameworks>net461;net10.0</TargetFrameworks>
     <PackageId>Paket</PackageId>
     <AssemblyName>paket</AssemblyName>
     <IsPackable>true</IsPackable>
@@ -12,7 +12,7 @@
     <!-- .net tools support netcoreapp only -->
     <TargetFrameworks>
     </TargetFrameworks>
-    <TargetFramework>net9</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />

--- a/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
+++ b/tests/Paket.Bootstrapper.Tests/Paket.Bootstrapper.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net461;net9</TargetFrameworks>
+    <TargetFrameworks>net461;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Paket.Tests/Paket.Tests.fsproj
+++ b/tests/Paket.Tests/Paket.Tests.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net461;net9</TargetFrameworks>
+    <TargetFrameworks>net461;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <!-- these two properties are set for some tests around assembly metadata parsing.
          they're written to the generated AssemblyInfo.fs -->


### PR DESCRIPTION
Upgrades the build to the .NET 10 SDK and retargets the produced binaries from `net9` to `net10.0`, following the same shape as the .NET 9 upgrade in d3b6d43c8 that `DEV_GUIDE.md` points to as the reference procedure.

## Prerequisite: the local paket tool

`.config/dotnet-tools.json` pinned paket **9.0.2**, which predates net10.0 support (added in 10.0.1). Since `build.sh` runs `dotnet paket restore` with that tool, it had to be bumped to 10.3.1 before the projects could retarget. The tool regenerates `.paket/Paket.Restore.targets`, which picks up the group conditions plumbing from 10.1.1 — the file now depends on the `show-conditions` command and so requires paket >= 10.1.1.

Note this file still lags `src/Paket.Core/embedded/Paket.Restore.targets`, which carries unreleased fixes. That divergence is pre-existing and inherent to self-hosting: any restore with a released tool rewrites the file with the released content.

## Two regressions surfaced by the SDK

`TreatWarningsAsErrors=true` turns every new diagnostic into a build failure.

- **NU1510** (x35): NuGet 10 flags framework-provided `PackageReference`s as prunable. They come from paket's transitive resolution of `NETStandard.Library`, not from hand-written references, so they cannot simply be removed — added to `WarningsNotAsErrors` alongside the existing exemptions.
- **FS0049** in `SemVer.fs`: the F# 10 compiler rejects the `Int M` pattern binding. Renamed to `ma`; behaviour unchanged.

## Impact on consumers

The `paket` .NET tool moves to `net10.0`, so its minimum runtime goes from .NET 9 to .NET 10. The ILRepack-merged `paket.exe` still targets `net461`, so the bootstrapper / .NET Framework path is unaffected. Released here as `11.0.0-alpha001`.
