### PR TITLE
build: run build.fsx with dotnet fsi instead of the FAKE runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Repository build targets:
 ./build.sh
 ```
 
-On Windows, use the corresponding `build.cmd` commands. The full build restores tools and dependencies, builds all projects, and runs broad test suites; on Linux it also depends on Mono and system tooling. If those prerequisites are unavailable, run the relevant `dotnet test` command and report what was not validated.
+On Windows, use the corresponding `build.cmd` commands. Both scripts run `build.fsx` with `dotnet fsi`, so the build script itself only needs the .NET SDK declared in `global.json`. The full build restores tools and dependencies, builds all projects, and runs broad test suites; on Linux it still depends on Mono for the targets that run .NET Framework binaries, namely `MergePaketTool` (ILRepack) and the `net461` test passes. If those prerequisites are unavailable, run the relevant `dotnet test` command and report what was not validated.
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ Paket is a dependency manager for .NET with support for NuGet packages and git r
 
 ## Build Commands
 
+Both scripts run `build.fsx` with `dotnet fsi`; FAKE is used as a library, there is no FAKE runner
+to install.
+
 ```bash
 # Full build (restores, builds, runs tests)
 build.cmd                    # Windows
@@ -21,10 +24,14 @@ build.cmd QuickIntegrationTests  # Run quick integration tests (scriptgen catego
 build.cmd RunIntegrationTestsNet # Run full .NET Framework integration tests
 build.cmd RunIntegrationTestsNetCore # Run full .NET Core integration tests
 
-# Skip specific stages
-build.cmd SkipTests          # Skip all tests
-build.cmd SkipIntegrationTests # Skip integration tests only
+# Skip specific stages: these are build parameters, so they take a value and
+# come after the target name (they can also be passed as environment variables)
+build.cmd BuildPackage SkipTests=true            # Skip all tests
+build.cmd BuildPackage SkipIntegrationTests=true # Skip integration tests only
 ```
+
+Mono is still required on Linux for the targets that run .NET Framework binaries: `MergePaketTool`
+(ILRepack) and the `net461` test passes.
 
 ## Testing
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -4,6 +4,18 @@ Please contribute any notes that made your contributions easier here.
 
 Note that historically, the bulk of the development occured on Windows before dotnet got cross platform, for now, the tooling to target .NET Framework is still required for some areas.
 
+# Notes about the build script
+
+`build.cmd` and `build.sh` run `build.fsx` with `dotnet fsi`. FAKE is used as a library only: there
+is no FAKE runner to install, and its version no longer has to match the .NET SDK. Targets and
+parameters are unchanged, so `./build.sh <Target> [key=value ...]` keeps working as before — the
+script translates those arguments into environment variables itself, which is what the FAKE runner
+used to do.
+
+Mono is still needed on Linux for the targets that execute .NET Framework binaries: `MergePaketTool`
+(which runs `ILRepack.exe`) and the `net461` test passes. Removing that is tracked separately in
+[#4348](https://github.com/fsprojects/Paket/issues/4348).
+
 # Notes about the Paket F# Interactive extension
 
 Some pointers to help efforts to foster the F# Interactive extension ecosystem:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For more reasons see the [FAQ][10].
  - Build the solution with Visual Studio, `build.cmd` or `build.sh`.
  - Create a topic specific branch in git. Add a nice feature in the code. Do not
    forget to add tests and/or docs.
- - Run `build.cmd` (`build.sh` on Mono) to make sure all tests are still
+ - Run `build.cmd` (`build.sh` on Linux/macOS) to make sure all tests are still
    passing.
  - When built, you'll find the binaries in `./bin` which you can then test
    with locally, to ensure the bug or feature has been successfully implemented.

--- a/build.cmd
+++ b/build.cmd
@@ -9,6 +9,6 @@ if errorlevel 1 (
 setlocal
 
 
-packages\build\FAKE\tools\FAKE.exe build.fsx %*
+dotnet fsi build.fsx %*
 
 endlocal

--- a/build.fsx
+++ b/build.fsx
@@ -15,6 +15,19 @@ open Fake.Testing.NUnit3
 open System.Security.Cryptography
 open System.Xml.Linq
 
+// This script is run with `dotnet fsi`, so there is no FAKE.exe runner to parse the
+// command line for us. The runner used to turn `build.sh <Target> key=value ...` into
+// environment variables, which FAKE then reads back through getBuildParam/hasBuildParam.
+// Do that translation here, before any value below reads a build parameter.
+let private commandLineArgs =
+    let all = Environment.GetCommandLineArgs()
+    if all.Length > 2 then all.[2..] else [||] // skip fsi.dll and build.fsx
+
+for arg in commandLineArgs do
+    match arg.IndexOf '=' with
+    | i when i > 0 -> Environment.SetEnvironmentVariable(arg.Substring(0, i), arg.Substring(i + 1))
+    | _ -> Environment.SetEnvironmentVariable("target", arg)
+
 // Information about the project are used
 //  - for version and project name in generated AssemblyInfo file
 //  - by the generated NuGet package
@@ -76,8 +89,6 @@ let buildMergedDir = buildDir @@ "merged"
 let paketFile = buildMergedDir @@ "paket.exe"
 
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
-
-System.Net.ServicePointManager.SecurityProtocol <- unbox 192 ||| unbox 768 ||| unbox 3072 ||| unbox 48
 
 // Read additional information from the release notes document
 let releaseNotesData =

--- a/build.sh
+++ b/build.sh
@@ -1,35 +1,10 @@
 #!/usr/bin/env bash
-if test "$OS" = "Windows_NT"
-then
-  # use .Net
-  dotnet tool restore
-  dotnet paket restore
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-  	exit $exit_code
-  fi
-  MSBuild=`pwd -W`/packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
-else
-  dotnet tool restore
-  dotnet paket restore
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-    certificate_count=$(certmgr -list -c Trust | grep X.509 | wc -l)
-    if [ $certificate_count -le 1 ]; then
-      echo "Couldn't download Paket. This might be because your Mono installation"
-      echo "doesn't have the right SSL root certificates installed. One way"
-      echo "to fix this would be to download the list of SSL root certificates"
-      echo "from the Mozilla project by running the following command:"
-      echo ""
-      echo "    mozroots --import --sync"
-      echo ""
-      echo "This will import over 100 SSL root certificates into your Mono"
-      echo "certificate repository. Then try running the build script again."
-    fi
-    exit $exit_code
-  fi
-  # Note: the bundled MSBuild crashes hard on linux, so we still rely on the system-installed version
-  #export MSBuild=packages/build/RoslynTools.MSBuild/tools/msbuild/MSBuild.exe
-  mono packages/build/FAKE/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
-fi
+set -eu
+set -o pipefail
 
+cd "$(dirname "$0")"
+
+dotnet tool restore
+dotnet paket restore
+
+dotnet fsi build.fsx "$@"


### PR DESCRIPTION
First step towards #4348.

The build is started through `mono packages/build/FAKE/tools/FAKE.exe`, a .NET Framework
executable. That **runner** is what forces Mono on Linux, pulls in the legacy MSBuild discovery and
the obsolete `RoslynTools.MSBuild` path behind #4002, and has to stay in step with the .NET SDK.

The problem is the runner, not the library. So this PR only changes how the script is started:
`build.fsx` stays the same FAKE 4.64.17 script, but runs under `dotnet fsi`.

Upgrading to FAKE 6 is deliberately left for later: it would mean rewriting the ~730 lines of the
script (every API is renamed), replacing `Octokit.fsx` with `Fake.Api.GitHub` and moving the GitHub
release to a token. None of that is needed to drop the runner.

## Changes

- `build.sh` / `build.cmd` call `dotnet fsi build.fsx`. The Mono-specific `certmgr` / `mozroots`
  diagnostics block goes away, as does the `RoslynTools.MSBuild` line (that package is not even in
  `paket.dependencies` any more).
- `build.fsx` gains ~10 lines: without the runner the script has to parse its own command line, so
  it translates `<Target> key=value ...` into the environment variables FAKE reads back through
  `getBuildParam` / `hasBuildParam`. It runs before any other binding, because top-level values such
  as `testSuiteFilterFlakyTests` read build parameters while the script loads.
- `build.fsx` drops the `ServicePointManager.SecurityProtocol` assignment. It enabled TLS 1.2 on old
  runtimes and now throws `NotSupportedException` on .NET 10, since it also requests SSL3.
- Documentation updated. `CLAUDE.md`'s skip examples are corrected on the way: skip switches are
  build parameters, not targets, so they take a value and follow the target name — the documented
  `build.cmd SkipTests` was read as a target name and never worked.

No change to `paket.dependencies` / `paket.lock`, to the targets, to the produced artifacts, to the
target frameworks, or to `ci.yml`.

## What this does not do

Mono is still installed and still required, for the targets that execute .NET Framework binaries:
`MergePaketTool` (which runs `ILRepack.exe`) and the `net461` test passes. FAKE keeps prefixing those
with `mono` on its own, so they needed no change. Removing that is the next step.

## Validation

Run on Linux, .NET SDK 10.0.400:

- `dotnet fsi build.fsx CleanDocs` — target selection works, only that target runs.
- `dotnet fsi build.fsx Build` — OK.
- `dotnet fsi build.fsx Publish` — OK, produces `bin/net461/paket.exe`, `bin/net10.0/paket.dll`,
  `bin_bootstrapper/net461/paket.bootstrapper.exe`, `bin_bootstrapper/net10.0/paket.bootstrapper.dll`.
- `dotnet fsi build.fsx MergePaketTool` — OK, including `RunTests` through the target graph.
  `bin/merged/paket.exe` is produced and runs: `Paket version 11.0.0-alpha001`.

Worth a look on Windows CI, since `build.cmd` under `dotnet fsi` could not be exercised locally.

Also checked while porting: `FakeLib.dll` (which targets `.NETFramework,Version=v4.5`) loads fine
under .NET 10, as do `#load` of `Octokit.fsx` and the `#r` of the GAC assemblies at the top of the
script; `isMono` still evaluates to `true` on Linux, so the `not isMono` guards keep the exact same
"not Windows" meaning as before.

## Follow-ups for #4348

1. Replace `ILRepack.exe` with the `dotnet-ilrepack` tool and restrict the `net461` test passes to
   Windows — only then can `Install Mono` leave `ci.yml`.
2. Move FAKE 4 to FAKE 6 as a library. Note for whoever does it: `DotNet.test` defaults to
   `Configuration = Debug` in FAKE 6 while build/publish/pack default to `Release`, so with
   `--no-build` the tests would look in `bin/Debug`.
3. Documentation generation still runs on FAKE 4 and FSharp.Formatting 3 (the package only ships
   `lib/net40`), which is why `FAKE < 5` stays in the `Build` group.